### PR TITLE
[refactor] #4 - JWT 인증 구조를 httpOnly 쿠키 기반으로 변경(❌ 잘못된 PR)

### DIFF
--- a/src/main/java/com/cloudrangers/cloudpilot/CloudpilotApplication.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/CloudpilotApplication.java
@@ -2,12 +2,13 @@ package com.cloudrangers.cloudpilot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
 public class CloudpilotApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(CloudpilotApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(CloudpilotApplication.class, args);
 
+    }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/config/SecurityConfig.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/config/SecurityConfig.java
@@ -12,8 +12,12 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.*;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -24,32 +28,56 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
         http
-                // ✅ CSRF 비활성화 및 세션 비사용
+                // CSRF: REST + JWT(쿠키) 환경에서는 disable
                 .csrf(AbstractHttpConfigurer::disable)
+
+                // 세션 비활성화 → JWT 인증 방식 유지
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                // ✅ 접근 권한 설정
+                // 접근 권한
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**").permitAll()  // 로그인, 회원가입은 모두 접근 가능
+                        .requestMatchers("/auth/**").permitAll()   // 로그인/회원가입/리셋 등 프리패스
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Preflight 허용
                         .anyRequest().authenticated()              // 나머지는 JWT 필요
                 )
 
-                // ✅ JWT 필터 등록
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                // JWT 필터 등록
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+                // CORS 설정 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         return http.build();
     }
 
-    /** ✅ 비밀번호 암호화기 Bean */
+    /** CORS 설정 */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true); // ★ 쿠키 허용 핵심
+
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    /** 비밀번호 암호기 */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    /** ✅ AuthenticationManager Bean (인증관리자) */
+    /** AuthenticationManager */
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        return configuration.getAuthenticationManager();
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/AuthController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/AuthController.java
@@ -3,11 +3,19 @@ package com.cloudrangers.cloudpilot.controller;
 import com.cloudrangers.cloudpilot.common.ApiResponse;
 import com.cloudrangers.cloudpilot.dto.request.LoginRequest;
 import com.cloudrangers.cloudpilot.dto.response.LoginResponse;
+import com.cloudrangers.cloudpilot.security.JwtProvider;
 import com.cloudrangers.cloudpilot.service.user.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -16,23 +24,111 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserService userService;
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, Object> redisTemplate;
 
-    /** ✅ 로그인 */
     @PostMapping("/login")
-    public ApiResponse<LoginResponse> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);
 
-        log.info("✅ 로그인 성공 - empno={}, role={}, team={}",
-                request.getEmpno(), response.getRole(), response.getTeam());
 
-        return ApiResponse.of(true, response, "로그인 성공");
+        // 🍪 ① Access Token 쿠키 생성
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", response.getAccessToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(60 * 60) // 1h
+                .build();
+
+        // 🍪 ② Refresh Token 쿠키 생성
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", response.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(60 * 60 * 24 * 14) // 2 weeks
+                .build();
+
+        LoginResponse sanitized = LoginResponse.builder()
+                .username(response.getUsername())
+                .roleCode(response.getRoleCode())
+                .roleName(response.getRoleName())
+                .teamName(response.getTeamName())
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                .body(ApiResponse.success(sanitized));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<Void>> refreshToken(
+            @CookieValue(value = "refresh_token", required = false) String refreshToken
+    ) {
+        if (refreshToken == null) {
+            return ResponseEntity.status(401)
+                    .body(ApiResponse.of(false, null, "리프레시 토큰이 없습니다."));
+        }
+
+        // 블랙리스트 체크
+        if (redisTemplate.hasKey("BLACKLIST:" + refreshToken)) {
+            return ResponseEntity.status(401)
+                    .body(ApiResponse.of(false, null, "만료되었거나 로그아웃된 토큰입니다."));
+        }
+
+        // refresh token 검증
+        if (!jwtProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(401)
+                    .body(ApiResponse.of(false, null, "리프레시 토큰이 유효하지 않습니다."));
+        }
+
+        String empno = jwtProvider.getEmpno(refreshToken);
+
+        // Claims 없이 AccessToken 새로 발급 (UserService의 로직 재활용)
+        Map<String, Object> claims = userService.buildClaims(empno);
+        String newAccessToken = jwtProvider.generateAccessToken(empno, claims);
+
+        ResponseCookie newAccessCookie = ResponseCookie.from("access_token", newAccessToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(60 * 30)  // 30분
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, newAccessCookie.toString())
+                .body(ApiResponse.success(null));
     }
 
     /** ✅ 로그아웃 (Redis 블랙리스트 등록) */
     @PostMapping("/logout")
-    public ApiResponse<Void> logout(@RequestHeader(value = "Authorization", required = false) String token) {
-        userService.logout(token);
-        log.info("🔒 로그아웃 완료 - token={}", token);
+    public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+
+        userService.logout(request);
+
+        // 쿠키 삭제
+        ResponseCookie clearAccess = ResponseCookie.from("access_token", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .build();
+
+        ResponseCookie clearRefresh = ResponseCookie.from("refresh_token", "")
+                .path("/")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .build();
+
+        response.addHeader("Set-Cookie", clearAccess.toString());
+        response.addHeader("Set-Cookie", clearRefresh.toString());
+
         return ApiResponse.of(true, null, "로그아웃이 완료되었습니다.");
     }
 

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/AuthController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/AuthController.java
@@ -3,13 +3,11 @@ package com.cloudrangers.cloudpilot.controller;
 import com.cloudrangers.cloudpilot.common.ApiResponse;
 import com.cloudrangers.cloudpilot.dto.request.LoginRequest;
 import com.cloudrangers.cloudpilot.dto.response.LoginResponse;
-import com.cloudrangers.cloudpilot.security.JwtProvider;
 import com.cloudrangers.cloudpilot.service.user.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -24,31 +22,18 @@ import java.util.Map;
 public class AuthController {
 
     private final UserService userService;
-    private final JwtProvider jwtProvider;
-    private final RedisTemplate<String, Object> redisTemplate;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
         LoginResponse response = userService.login(request);
 
-
-        // 🍪 ① Access Token 쿠키 생성
         ResponseCookie accessCookie = ResponseCookie.from("access_token", response.getAccessToken())
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(60 * 60) // 1h
-                .build();
+                .httpOnly(true).secure(true).sameSite("Strict")
+                .path("/").maxAge(3600).build();
 
-        // 🍪 ② Refresh Token 쿠키 생성
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", response.getRefreshToken())
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(60 * 60 * 24 * 14) // 2 weeks
-                .build();
+                .httpOnly(true).secure(true).sameSite("Strict")
+                .path("/").maxAge(60 * 60 * 24 * 14).build();
 
         LoginResponse sanitized = LoginResponse.builder()
                 .username(response.getUsername())
@@ -63,99 +48,60 @@ public class AuthController {
                 .body(ApiResponse.success(sanitized));
     }
 
+    // NEW — refresh()
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<Void>> refreshToken(
-            @CookieValue(value = "refresh_token", required = false) String refreshToken
-    ) {
-        if (refreshToken == null) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.of(false, null, "리프레시 토큰이 없습니다."));
-        }
+            @CookieValue(value = "refresh_token", required = false) String refreshToken) {
 
-        // 블랙리스트 체크
-        if (redisTemplate.hasKey("BLACKLIST:" + refreshToken)) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.of(false, null, "만료되었거나 로그아웃된 토큰입니다."));
-        }
-
-        // refresh token 검증
-        if (!jwtProvider.validateToken(refreshToken)) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.of(false, null, "리프레시 토큰이 유효하지 않습니다."));
-        }
-
-        String empno = jwtProvider.getEmpno(refreshToken);
-
-        // Claims 없이 AccessToken 새로 발급 (UserService의 로직 재활용)
-        Map<String, Object> claims = userService.buildClaims(empno);
-        String newAccessToken = jwtProvider.generateAccessToken(empno, claims);
+        String newAccessToken = userService.refresh(refreshToken);
 
         ResponseCookie newAccessCookie = ResponseCookie.from("access_token", newAccessToken)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
-                .path("/")
-                .maxAge(60 * 30)  // 30분
-                .build();
+                .httpOnly(true).secure(true).sameSite("Strict")
+                .path("/").maxAge(60 * 30).build();
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, newAccessCookie.toString())
                 .body(ApiResponse.success(null));
     }
 
-    /** ✅ 로그아웃 (Redis 블랙리스트 등록) */
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-
         userService.logout(request);
 
-        // 쿠키 삭제
         ResponseCookie clearAccess = ResponseCookie.from("access_token", "")
-                .path("/")
-                .maxAge(0)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .path("/").maxAge(0).httpOnly(true).secure(true).sameSite("Strict")
                 .build();
 
         ResponseCookie clearRefresh = ResponseCookie.from("refresh_token", "")
-                .path("/")
-                .maxAge(0)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("Strict")
+                .path("/").maxAge(0).httpOnly(true).secure(true).sameSite("Strict")
                 .build();
 
         response.addHeader("Set-Cookie", clearAccess.toString());
         response.addHeader("Set-Cookie", clearRefresh.toString());
 
-        return ApiResponse.of(true, null, "로그아웃이 완료되었습니다.");
+        return ApiResponse.success(null);
     }
 
-    /** ✅ 비밀번호 초기화 (이메일 발송) */
     @PostMapping("/password-reset")
     public ApiResponse<Void> sendPasswordReset(@RequestParam String email) {
         userService.sendPasswordResetEmail(email);
-        return ApiResponse.of(true, null, "비밀번호 재설정 이메일이 발송되었습니다.");
+        return ApiResponse.success(null);
     }
 
-    /** ✅ 비밀번호 재설정 (토큰 검증 후 새 비밀번호 저장) */
     @PostMapping("/password-reset/confirm")
     public ApiResponse<Void> confirmPasswordReset(
             @RequestParam String token,
-            @RequestParam String newPassword
-    ) {
+            @RequestParam String newPassword) {
         userService.confirmPasswordReset(token, newPassword);
-        return ApiResponse.of(true, null, "비밀번호가 성공적으로 재설정되었습니다.");
+        return ApiResponse.success(null);
     }
 
-    /** ✅ 로그인된 사용자의 비밀번호 변경 */
     @PostMapping("/password")
     public ApiResponse<Void> changePassword(
             @RequestParam String currentPassword,
-            @RequestParam String newPassword
-    ) {
+            @RequestParam String newPassword) {
         userService.changePassword(currentPassword, newPassword);
-        return ApiResponse.of(true, null, "비밀번호가 성공적으로 변경되었습니다.");
+        return ApiResponse.success(null);
     }
 }
+

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/User.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/User.java
@@ -1,10 +1,7 @@
 package com.cloudrangers.cloudpilot.domain.user;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,6 +11,8 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @ToString(exclude = "userRoles")
 @Table(name = "`user`") // ✅ 예약어 방지
 public class User {

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/UserRole.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/UserRole.java
@@ -1,15 +1,16 @@
 package com.cloudrangers.cloudpilot.domain.user;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(
         name = "user_role",
         uniqueConstraints = {

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/response/LoginResponse.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/response/LoginResponse.java
@@ -1,16 +1,37 @@
 package com.cloudrangers.cloudpilot.dto.response;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class LoginResponse {
 
     private String accessToken;
-    private String role;
-    private String team;
+    private String refreshToken;
     private String username;
+    private String roleCode;
+    private String roleName;
+    private Long teamId;
+    private String teamName;
+
+    @Builder
+    public LoginResponse(
+            String accessToken,
+            String refreshToken,
+            String username,
+            String roleCode,
+            String roleName,
+            Long teamId,
+            String teamName
+    ) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.username = username;
+        this.roleCode = roleCode;
+        this.roleName = roleName;
+        this.teamId = teamId;
+        this.teamName = teamName;
+    }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/exception/GlobalExceptionHandler.java
@@ -1,4 +1,27 @@
 package com.cloudrangers.cloudpilot.exception;
 
+import com.cloudrangers.cloudpilot.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CovigatorException.class)
+    public ApiResponse<Object> handleCovigatorException(CovigatorException ex) {
+
+        log.error("❌ Custom Exception 발생: {}", ex.getMessage());
+
+        return ApiResponse.fail(ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<Object> handleGeneralException(Exception ex) {
+
+        log.error("🔥 Unexpected System Error: ", ex);
+
+        return ApiResponse.fail("서버 내부 오류가 발생했습니다.");
+    }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/exception/badrequest/InvalidRequestException.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/exception/badrequest/InvalidRequestException.java
@@ -1,4 +1,11 @@
 package com.cloudrangers.cloudpilot.exception.badrequest;
 
-public class InvalidRequestException {
+import com.cloudrangers.cloudpilot.exception.CovigatorException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRequestException extends CovigatorException {
+
+    public InvalidRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, 10006, message);
+    }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/user/UserRoleRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/user/UserRoleRepository.java
@@ -1,0 +1,12 @@
+package com.cloudrangers.cloudpilot.repository.user;
+
+import com.cloudrangers.cloudpilot.domain.user.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+
+    List<UserRole> findByUserId(Long userId);
+
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/security/JwtProvider.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/security/JwtProvider.java
@@ -21,7 +21,8 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String secret;
 
-    private static final long ACCESS_EXPIRATION_MS = 1000 * 60 * 60; // 1시간
+    private static final long ACCESS_TOKEN_EXP_MS  = 1000L * 60 * 30;      // 30분
+    private static final long REFRESH_TOKEN_EXP_MS = 1000L * 60 * 60 * 24 * 14; // 14일
 
     private Key getSigningKey() {
         if (secret == null || secret.isBlank()) {
@@ -30,33 +31,25 @@ public class JwtProvider {
         return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
-    /** ✅ (1) 기본 Access Token 생성 (empno만 포함) */
-    public String generateToken(String empno) {
+    public String generateAccessToken(String empno, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setSubject(empno)
+                .addClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXP_MS))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String empno) {
         return Jwts.builder()
                 .setSubject(empno)
                 .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION_MS))
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXP_MS))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    /** ✅ (2) 커스텀 Claims를 포함한 Token 생성 */
-    public String generateTokenWithClaims(String subject, Map<String, Object> claims) {
-        return Jwts.builder()
-                .setSubject(subject)
-                .addClaims(claims)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION_MS))
-                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
-                .compact();
-    }
-
-    /** ✅ (3) 오버로드 버전 — empno, role, team 포함 */
-    public String generateToken(String empno, String role, String team) {
-        return generateTokenWithClaims(empno, Map.of("role", role, "team", team));
-    }
-
-    /** ✅ 토큰 유효성 검증 */
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
@@ -71,24 +64,7 @@ public class JwtProvider {
         }
     }
 
-    /** ✅ 토큰에서 empno 추출 */
-    public String getEmpno(String token) {
-        try {
-            return Jwts.parserBuilder()
-                    .setSigningKey(getSigningKey())
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody()
-                    .getSubject();
-        } catch (ExpiredJwtException e) {
-            throw new JwtExpiredException();
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new JwtInvalidException();
-        }
-    }
-
-    /** ✅ 토큰에서 Claims 전체 추출 */
-    public Claims getClaims(String token) {
+    public Claims parseClaims(String token) {
         try {
             return Jwts.parserBuilder()
                     .setSigningKey(getSigningKey())
@@ -97,20 +73,32 @@ public class JwtProvider {
                     .getBody();
         } catch (ExpiredJwtException e) {
             throw new JwtExpiredException();
-        } catch (JwtException | IllegalArgumentException e) {
+        } catch (JwtException e) {
             throw new JwtInvalidException();
         }
     }
 
-    /** ✅ 남은 만료 시간 계산 (Redis TTL 용도) */
+    public String getEmpno(String token) {
+        return parseClaims(token).getSubject();
+    }
+
     public long getRemainingExpiration(String token) {
         try {
-            Claims claims = getClaims(token);
             long now = System.currentTimeMillis();
-            long expiration = claims.getExpiration().getTime();
-            return Math.max(expiration - now, 0);
-        } catch (JwtException e) {
+            long exp = parseClaims(token).getExpiration().getTime();
+            return Math.max(exp - now, 0);
+        } catch (Exception e) {
             return 0;
         }
+    }
+
+    public String generateTokenWithClaims(String subject, Map<String, Object> claims) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .addClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXP_MS))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/user/PermissionService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/user/PermissionService.java
@@ -1,0 +1,58 @@
+package com.cloudrangers.cloudpilot.service.user;
+
+import com.cloudrangers.cloudpilot.domain.user.Role;
+import com.cloudrangers.cloudpilot.domain.user.UserRole;
+import com.cloudrangers.cloudpilot.repository.user.UserRoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PermissionService {
+
+    private final UserRoleRepository userRoleRepository;
+
+    /**
+     * 사용자에게 특정 권한이 있는지 확인
+     * 예: hasPermission(userId, "vm.create")
+     */
+    public boolean hasPermission(Long userId, String permissionKey) {
+        List<UserRole> userRoles = userRoleRepository.findByUserId(userId);
+
+        for (UserRole ur : userRoles) {
+            Role role = ur.getRole();
+            Map<String, Object> perm = role.getPermissions();
+
+            if (perm != null && Boolean.TRUE.equals(perm.get(permissionKey))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 권한이 없으면 예외 발생 — 컨트롤러/서비스에서 직접 호출 가능
+     */
+    public void checkPermission(Long userId, String permissionKey) {
+        if (!hasPermission(userId, permissionKey)) {
+            throw new RuntimeException("권한 부족: " + permissionKey);
+        }
+    }
+
+    /**
+     * 현재 사용자 권한 전체 반환 — 마이페이지/관리자 페이지에서 활용 가능
+     */
+    public Map<String, Object> getAllPermissions(Long userId) {
+        List<UserRole> userRoles = userRoleRepository.findByUserId(userId);
+
+        // 가장 높은 레벨(Role.permissionLevel이 최대인 role) 기준으로 반환 (일종의 merge)
+        return userRoles.stream()
+                .map(ur -> ur.getRole().getPermissions())
+                .filter(p -> p != null)
+                .findFirst()
+                .orElse(Map.of());
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/service/user/UserService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/user/UserService.java
@@ -2,12 +2,16 @@ package com.cloudrangers.cloudpilot.service.user;
 
 import com.cloudrangers.cloudpilot.dto.request.LoginRequest;
 import com.cloudrangers.cloudpilot.dto.response.LoginResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
 
 public interface UserService {
     LoginResponse login(LoginRequest request);
-    void logout(String token);
+    void logout(HttpServletRequest request);
     void sendPasswordResetEmail(String email);
     void confirmPasswordReset(String token, String newPassword);
     void changePassword(String currentPassword, String newPassword);
     void updateEmail(Long userId, String newEmail);
+    Map<String, Object> buildClaims(String empno);
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/user/UserService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/user/UserService.java
@@ -14,4 +14,6 @@ public interface UserService {
     void changePassword(String currentPassword, String newPassword);
     void updateEmail(Long userId, String newEmail);
     Map<String, Object> buildClaims(String empno);
+    String refresh(String refreshToken);
+
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/user/UserServiceImpl.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/user/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.cloudrangers.cloudpilot.service.user;
 
 import com.cloudrangers.cloudpilot.domain.user.User;
+import com.cloudrangers.cloudpilot.domain.user.UserRole;
 import com.cloudrangers.cloudpilot.dto.request.LoginRequest;
 import com.cloudrangers.cloudpilot.dto.response.LoginResponse;
 import com.cloudrangers.cloudpilot.exception.badrequest.InvalidPasswordException;
@@ -11,6 +12,7 @@ import com.cloudrangers.cloudpilot.security.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.lang.NonNull;
@@ -19,7 +21,7 @@ import jakarta.servlet.http.Cookie;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Comparator;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -31,9 +33,9 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
     private final PasswordEncoder passwordEncoder;
-
     private final RedisTemplate<String, Object> redisTemplate;
 
+    /** 로그인 */
     @Override
     public LoginResponse login(@NonNull LoginRequest request) {
 
@@ -44,141 +46,112 @@ public class UserServiceImpl implements UserService {
             throw new InvalidPasswordException();
         }
 
-        var userRole = user.getUserRoles().stream()
-                .max((a, b) -> a.getRole().getPermissionLevel() - b.getRole().getPermissionLevel())
-                .orElseThrow(() -> new RuntimeException("역할 정보가 없습니다."));
-
+        var userRole = getHighestUserRole(user);
         var role = userRole.getRole();
         var team = userRole.getTeam();
 
-        String roleCode = role.getCode();
-        String roleName = role.getName();
-        String scope    = (String) role.getPermissions().get("scope");
+        Map<String, Object> claims = buildClaims(String.valueOf(user.getEmpno()));
 
-        Long teamId = (team != null) ? team.getId() : null;
-        String teamName = (team != null) ? team.getName() : "GLOBAL";
-
-        String username = user.getUsername();
-
-        // ❗ claims 생성 (null 제거)
-        Map<String, Object> claims = new HashMap<>();
-        claims.put("role", roleCode);
-        claims.put("teamId", teamId);
-        claims.put("team", teamName);
-        if (scope != null) claims.put("scope", scope);
-
-        // access token 생성
-        String accessToken = jwtProvider.generateAccessToken(
-                String.valueOf(user.getEmpno()),
-                claims
-        );
-
-        String refreshToken = jwtProvider.generateRefreshToken(
-                String.valueOf(user.getEmpno())
-        );
+        String accessToken = jwtProvider.generateAccessToken(String.valueOf(user.getEmpno()), claims);
+        String refreshToken = jwtProvider.generateRefreshToken(String.valueOf(user.getEmpno()));
 
         return LoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .username(username)
-                .roleCode(roleCode)
-                .roleName(roleName)
-                .teamId(teamId)
-                .teamName(teamName)
+                .username(user.getUsername())
+                .roleCode(role.getCode())
+                .roleName(role.getName())
+                .teamId(team != null ? team.getId() : null)
+                .teamName(team != null ? team.getName() : "GLOBAL")
                 .build();
-
     }
 
-    /** ✅ Redis 기반 로그아웃 */
+    /** refresh token → 새로운 access token */
     @Override
-    public void logout( HttpServletRequest request) {
+    public String refresh(String refreshToken) {
 
-        // 1) 쿠키에서 access_token 읽기
+        if (refreshToken == null) {
+            throw new InvalidTokenException("리프레시 토큰이 없습니다.");
+        }
+
+        if (redisTemplate.hasKey("BLACKLIST:" + refreshToken)) {
+            throw new InvalidTokenException("만료되었거나 로그아웃된 토큰입니다.");
+        }
+
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new InvalidTokenException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        String empno = jwtProvider.getEmpno(refreshToken);
+        Map<String, Object> claims = buildClaims(empno);
+
+        return jwtProvider.generateAccessToken(empno, claims);
+    }
+
+    /** 로그아웃 */
+    @Override
+    public void logout(HttpServletRequest request) {
+
         String token = extractTokenFromCookies(request);
 
         if (token == null) {
             throw new InvalidTokenException("로그아웃할 access_token 쿠키가 없습니다.");
         }
 
-        // 2) JWT 검증
         if (!jwtProvider.validateToken(token)) {
             throw new InvalidTokenException("유효하지 않은 토큰입니다.");
         }
 
-        // 3) 남은 만료시간 계산
         long expiration = jwtProvider.getRemainingExpiration(token);
 
-        // 4) 블랙리스트 등록
-        redisTemplate.opsForValue()
-                .set("BLACKLIST:" + token, "logout", expiration, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set("BLACKLIST:" + token, "logout",
+                expiration, TimeUnit.MILLISECONDS);
 
-        log.info("🚫 로그아웃: 블랙리스트 등록완료 token={}", token);
+        log.info("🚫 로그아웃 완료: {}", token);
     }
 
-    // Helper: 쿠키에서 access_token 추출
-    private String extractTokenFromCookies(HttpServletRequest request) {
-
-        if (request.getCookies() == null) return null;
-
-        for (Cookie cookie : request.getCookies()) {
-            if (cookie.getName().equals("access_token")) {
-                return cookie.getValue();
-            }
-        }
-        return null;
-    }
-
-
-
+    /** 비밀번호 초기화 */
     @Override
     public void sendPasswordResetEmail(String email) {
+
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException(email));
 
-        // 임시 토큰 생성 (UUID)
         String resetToken = UUID.randomUUID().toString();
 
-        // Redis에 저장 (15분 유효)
-        redisTemplate.opsForValue()
-                .set("PWD_RESET:" + email, resetToken, 15, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set("PWD_RESET_TOKEN:" + resetToken, email, 15, TimeUnit.MINUTES);
 
-        // 이메일 전송 대신 로그로 확인 (SMTP 나중에 교체 가능)
-        log.info("📩 비밀번호 재설정 토큰 발급: email={}, token={}", email, resetToken);
+        log.info("📩 비밀번호 재설정 토큰 발급: {}", resetToken);
     }
 
-
+    /** 비밀번호 재설정 */
     @Override
     public void confirmPasswordReset(String token, String newPassword) {
-        // Redis에서 해당 토큰 검색
-        Optional<String> emailOpt = redisTemplate.keys("PWD_RESET:*").stream()
-                .filter(key -> token.equals(redisTemplate.opsForValue().get(key)))
-                .map(key -> key.replace("PWD_RESET:", ""))
-                .findFirst();
 
-        if (emailOpt.isEmpty()) {
+        String email = (String) redisTemplate.opsForValue().get("PWD_RESET_TOKEN:" + token);
+
+        if (email == null) {
             throw new InvalidTokenException("비밀번호 재설정 토큰이 유효하지 않거나 만료되었습니다.");
         }
 
-        String email = emailOpt.get();
-
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException(email));
 
-        // 새 비밀번호 저장
         user.setPasswordHash(passwordEncoder.encode(newPassword));
         userRepository.save(user);
 
-        // 토큰 사용 후 삭제
-        redisTemplate.delete("PWD_RESET:" + email);
+        redisTemplate.delete("PWD_RESET_TOKEN:" + token);
 
         log.info("✅ 비밀번호 재설정 완료: {}", email);
     }
 
+    /** 비밀번호 변경 */
     @Override
     public void changePassword(String currentPassword, String newPassword) {
-        // TODO: SecurityContextHolder에서 현재 사용자 정보(empno) 추출 후 로직 완성
-        // 임시 예시 (테스트용)
-        Long empno = 1001L;
+
+        Long empno = Long.valueOf(
+                SecurityContextHolder.getContext().getAuthentication().getName()
+        );
 
         User user = userRepository.findByEmpno(empno)
                 .orElseThrow(() -> new UserNotFoundException(empno));
@@ -193,30 +166,45 @@ public class UserServiceImpl implements UserService {
         log.info("🔑 비밀번호 변경 완료: {}", empno);
     }
 
-    @Override
-    public void updateEmail(Long userId, String newEmail) {
-        // TODO: 이메일 변경 로직
-    }
-
+    /** 공통 Claims 빌더 */
     @Override
     public Map<String, Object> buildClaims(String empno) {
 
         User user = userRepository.findWithRolesByEmpno(Long.valueOf(empno))
                 .orElseThrow(() -> new UserNotFoundException(empno));
 
-        var userRole = user.getUserRoles().stream()
-                .max((a, b) -> a.getRole().getPermissionLevel() - b.getRole().getPermissionLevel())
-                .orElseThrow(() -> new RuntimeException("역할 정보가 없습니다."));
-
+        var userRole = getHighestUserRole(user);
         var role = userRole.getRole();
         var team = userRole.getTeam();
 
         Map<String, Object> claims = new HashMap<>();
-
         claims.put("role", role.getCode());
         claims.put("teamId", team != null ? team.getId() : null);
         claims.put("team", team != null ? team.getName() : "GLOBAL");
 
         return claims;
+    }
+
+    /** 역할 우선순위 계산 */
+    private UserRole getHighestUserRole(User user) {
+        return user.getUserRoles().stream()
+                .max(Comparator.comparingInt(a -> a.getRole().getPermissionLevel()))
+                .orElseThrow(() -> new RuntimeException("역할 정보가 없습니다."));
+    }
+
+    /** Access token 추출 */
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("access_token")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void updateEmail(Long userId, String newEmail) {
+        // TODO: 이메일 변경 로직
     }
 }


### PR DESCRIPTION
📌 Summary

- JWT 인증 구조를 httpOnly Cookie 기반으로 전면 리팩토링

✍️ Description

- Access Token / Refresh Token 을 JSON 응답에서 제거하고 httpOnly Cookie로 저장되도록 변경

- 필터(JwtAuthenticationFilter)에서 Authorization 헤더 뿐 아니라 Cookie에서도 access_token 조회하도록 구조 개편

- 로그아웃 시 쿠키 삭제 + Redis 블랙리스트 등록 로직 개선

- close: #4

💡 PR Point

- 로그인 이후 Authorization 헤더 없이도 정상 인증 되는지 확인

- 만료된 토큰이 쿠키에 있을 때 필터에서 Expired 에러를 잘 처리하는지 확인

- 로그아웃 시 쿠키 삭제 및 Redis 블랙리스트 등록 정상 동작 여부

📚 Reference

- JWT Cookie 기반 인증 구조(SPA + Spring Security)

- Redis blacklist logout pattern

🔥 Test

1. 로그인 (`POST /auth/login`)

| 테스트 내용 |
|---|
| 로그인 성공 시 `Set-Cookie`로 access_token, refresh_token 내려오는지 확인 |

📸 캡처  
<img width="1150" height="760" alt="image" src="https://github.com/user-attachments/assets/35e94334-adec-427d-8091-804d32b88375" />

---

2. Access Token 만료 후 Refresh (`POST /auth/refresh`)

| 테스트 내용 |
|---|
| access_token 만료 후 refresh_token으로 새 access_token 정상 발급 |

📸 캡처  
<img width="1150" height="760" alt="image" src="https://github.com/user-attachments/assets/fef15a4c-b03e-443b-9e76-46111c44a9da" />

---

3. 로그아웃 (`POST /auth/logout`)

| 테스트 내용 |
|---|
| 쿠키 삭제 및 Redis 블랙리스트 등록 정상 동작 |

📸 캡처  
<img width="1150" height="760" alt="image" src="https://github.com/user-attachments/assets/59aebe87-0953-4e4a-abbb-551431fa1520" />
