### PR TITLE
[feat] #20 - JWT 기반 권한 구조 적용 및 로그인 응답에 역할·팀 정보 포함

### DIFF
--- a/src/main/java/com/cloudrangers/cloudpilot/config/SecurityConfig.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.cloudrangers.cloudpilot.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,7 +13,6 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.*;
@@ -30,38 +30,30 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
         http
-                // CSRF: REST + JWT(쿠키) 환경에서는 disable
                 .csrf(AbstractHttpConfigurer::disable)
-
-                // 세션 비활성화 → JWT 인증 방식 유지
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                // 접근 권한
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**").permitAll()   // 로그인/회원가입/리셋 등 프리패스
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Preflight 허용
-                        .anyRequest().authenticated()              // 나머지는 JWT 필요
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-
-                // JWT 필터 등록
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/packages/approve/**").hasAnyRole("HEAD", "LEADER")
+                        .anyRequest().authenticated()
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-
-                // CORS 설정 적용
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         return http.build();
     }
 
-    /** CORS 설정 */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:3000"));
+        config.setAllowedOriginPatterns(List.of("http://localhost:*"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
-        config.setAllowCredentials(true); // ★ 쿠키 허용 핵심
-
+        config.setAllowCredentials(true);
         config.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
@@ -69,16 +61,13 @@ public class SecurityConfig {
         return source;
     }
 
-    /** 비밀번호 암호기 */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    /** AuthenticationManager */
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
     }
-
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/AuthController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.cloudrangers.cloudpilot.controller;
 import com.cloudrangers.cloudpilot.common.ApiResponse;
 import com.cloudrangers.cloudpilot.dto.request.LoginRequest;
 import com.cloudrangers.cloudpilot.dto.response.LoginResponse;
+import com.cloudrangers.cloudpilot.security.JwtProvider;
 import com.cloudrangers.cloudpilot.service.user.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,8 +14,6 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @Slf4j
 @RestController
 @RequestMapping("/auth")
@@ -22,42 +21,45 @@ import java.util.Map;
 public class AuthController {
 
     private final UserService userService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
-        LoginResponse response = userService.login(request);
 
-        ResponseCookie accessCookie = ResponseCookie.from("access_token", response.getAccessToken())
+        LoginResponse info = userService.login(request);
+
+        String empno = String.valueOf(request.getEmpno());
+        var claims = userService.buildClaims(empno);
+
+        String accessToken = jwtProvider.generateAccessToken(empno, claims);
+        String refreshToken = jwtProvider.generateRefreshToken(empno);
+
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", accessToken)
                 .httpOnly(true).secure(true).sameSite("Strict")
-                .path("/").maxAge(3600).build();
+                .path("/").maxAge(60 * 30).build();
 
-        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", response.getRefreshToken())
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true).secure(true).sameSite("Strict")
-                .path("/").maxAge(60 * 60 * 24 * 14).build();
-
-        LoginResponse sanitized = LoginResponse.builder()
-                .username(response.getUsername())
-                .roleCode(response.getRoleCode())
-                .roleName(response.getRoleName())
-                .teamName(response.getTeamName())
-                .build();
+                .path("/").maxAge(60L * 60 * 24 * 14).build();
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
-                .body(ApiResponse.success(sanitized));
+                .body(ApiResponse.success(info));
     }
 
-    // NEW — refresh()
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<Void>> refreshToken(
-            @CookieValue(value = "refresh_token", required = false) String refreshToken) {
+    public ResponseEntity<ApiResponse<Void>> refreshToken(HttpServletRequest request) {
 
-        String newAccessToken = userService.refresh(refreshToken);
+        String newAccessToken = userService.refresh(request);
 
         ResponseCookie newAccessCookie = ResponseCookie.from("access_token", newAccessToken)
-                .httpOnly(true).secure(true).sameSite("Strict")
-                .path("/").maxAge(60 * 30).build();
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Strict")
+                .path("/")
+                .maxAge(60 * 30)
+                .build();
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, newAccessCookie.toString())
@@ -66,15 +68,14 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+
         userService.logout(request);
 
         ResponseCookie clearAccess = ResponseCookie.from("access_token", "")
-                .path("/").maxAge(0).httpOnly(true).secure(true).sameSite("Strict")
-                .build();
+                .path("/").maxAge(0).httpOnly(true).secure(true).sameSite("Strict").build();
 
         ResponseCookie clearRefresh = ResponseCookie.from("refresh_token", "")
-                .path("/").maxAge(0).httpOnly(true).secure(true).sameSite("Strict")
-                .build();
+                .path("/").maxAge(0).httpOnly(true).secure(true).sameSite("Strict").build();
 
         response.addHeader("Set-Cookie", clearAccess.toString());
         response.addHeader("Set-Cookie", clearRefresh.toString());
@@ -104,4 +105,3 @@ public class AuthController {
         return ApiResponse.success(null);
     }
 }
-

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/Role.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/Role.java
@@ -1,15 +1,19 @@
 package com.cloudrangers.cloudpilot.domain.user;
 
+import com.cloudrangers.cloudpilot.domain.user.converter.JsonToMapConverter;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "role")
 public class Role {
 
@@ -30,12 +34,12 @@ public class Role {
     @Column(name = "permission_level", nullable = false)
     private Integer permissionLevel;
 
-    /** JSON 필드: {"vm": {...}, "package": {...}} */
+    /** JSON 필드: {"vm": {...}, "package": {...}, "scope": "..."} */
     @Column(name = "permissions", columnDefinition = "json")
-    @Convert(converter = com.cloudrangers.cloudpilot.domain.user.converter.JsonToMapConverter.class)
+    @Convert(converter = JsonToMapConverter.class)
     private Map<String, Object> permissions;
 
-    /** UserRole과의 양방향 관계 (선택적) */
+    /** UserRole과의 양방향 관계 */
     @OneToMany(mappedBy = "role", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private java.util.List<UserRole> userRoles = new java.util.ArrayList<>();
+    private List<UserRole> userRoles = new ArrayList<>();
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/Team.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/Team.java
@@ -4,15 +4,17 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
-@Table(name = "team")
+@Table(name = "team",
+        indexes = {
+                @Index(name = "idx_team_name", columnList = "name")
+        })
 public class Team {
 
     @Id
@@ -20,7 +22,7 @@ public class Team {
     @Column(name = "id")
     private Long id;
 
-    /** 팀 이름 (예: 개발팀, 모니터링팀 등) */
+    /** 팀 이름 */
     @Column(name = "name", nullable = false, unique = true, length = 200)
     private String name;
 
@@ -28,16 +30,15 @@ public class Team {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
-    /** 생성 일시 */
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
-
-    /** UserRole과의 양방향 관계 (팀 → 사용자역할) */
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<UserRole> userRoles = new ArrayList<>();
+    /** 생성 시각 (DB DEFAULT CURRENT_TIMESTAMP) */
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/User.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/User.java
@@ -14,7 +14,13 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @ToString(exclude = "userRoles")
-@Table(name = "`user`") // ✅ 예약어 방지
+@Table(
+        name = "`user`",
+        indexes = {
+                @Index(name = "idx_user_username", columnList = "username"),
+                @Index(name = "idx_user_email", columnList = "email")
+        }
+)
 public class User {
 
     @Id
@@ -28,16 +34,18 @@ public class User {
     @Column(name = "email", nullable = false, unique = true, length = 255)
     private String email;
 
-    @Column(name = "empno", nullable = false, unique = true)
+    @Column(name = "empno", nullable = false)
     private Long empno;
 
     @Column(name = "password_hash", nullable = false, length = 255)
     private String passwordHash;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", nullable = false)
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
@@ -46,8 +54,8 @@ public class User {
     @PrePersist
     protected void onCreate() {
         LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
+        if (this.createdAt == null) this.createdAt = now;
+        if (this.updatedAt == null) this.updatedAt = now;
     }
 
     @PreUpdate

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/UserRole.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/UserRole.java
@@ -24,27 +24,23 @@ public class UserRole {
     @Column(name = "id")
     private Long id;
 
-    /** 사용자 */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    /** 역할 */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id", nullable = false)
     private Role role;
 
-    /** 팀 */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
 
-    /** 역할 부여 시각 */
     @Column(name = "assigned_at", nullable = false, updatable = false)
-    private LocalDateTime assignedAt = LocalDateTime.now();
+    private LocalDateTime assignedAt;
 
     @PrePersist
     protected void onCreate() {
-        this.assignedAt = LocalDateTime.now();
+        if (assignedAt == null) assignedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/user/converter/JsonToMapConverter.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/user/converter/JsonToMapConverter.java
@@ -1,10 +1,12 @@
 package com.cloudrangers.cloudpilot.domain.user.converter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.util.HashMap;
+
+import java.util.Collections;
 import java.util.Map;
 
 @Converter
@@ -12,9 +14,15 @@ public class JsonToMapConverter implements AttributeConverter<Map<String, Object
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    /**
+     * Map → JSON 저장 (DB 저장용)
+     */
     @Override
     public String convertToDatabaseColumn(Map<String, Object> attribute) {
-        if (attribute == null || attribute.isEmpty()) return "{}";
+        if (attribute == null || attribute.isEmpty()) {
+            return "{}";
+        }
+
         try {
             return objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
@@ -22,11 +30,20 @@ public class JsonToMapConverter implements AttributeConverter<Map<String, Object
         }
     }
 
+    /**
+     * JSON → Map 읽기 (Entity 로딩용)
+     */
     @Override
     public Map<String, Object> convertToEntityAttribute(String dbData) {
-        if (dbData == null || dbData.isBlank()) return new HashMap<>();
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyMap();
+        }
+
         try {
-            return objectMapper.readValue(dbData, Map.class);
+            return objectMapper.readValue(
+                    dbData,
+                    new TypeReference<Map<String, Object>>() {}
+            );
         } catch (Exception e) {
             throw new IllegalArgumentException("Error converting JSON to Map", e);
         }

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/request/LoginRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/request/LoginRequest.java
@@ -12,6 +12,6 @@ public class LoginRequest {
     private Long empno;
 
     @NotNull(message = "비밀번호는 필수 입력값입니다.")
-    @Size(min = 4, max = 100, message = "비밀번호는 8자 이상 100자 이하로 입력해주세요.")
+    @Size(min = 8, max = 100, message = "비밀번호는 8자 이상 100자 이하로 입력해주세요.")
     private String password;
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/response/LoginResponse.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/response/LoginResponse.java
@@ -8,8 +8,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LoginResponse {
 
-    private String accessToken;
-    private String refreshToken;
     private String username;
     private String roleCode;
     private String roleName;
@@ -18,16 +16,12 @@ public class LoginResponse {
 
     @Builder
     public LoginResponse(
-            String accessToken,
-            String refreshToken,
             String username,
             String roleCode,
             String roleName,
             Long teamId,
             String teamName
     ) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
         this.username = username;
         this.roleCode = roleCode;
         this.roleName = roleName;

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/user/UserRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/user/UserRepository.java
@@ -10,7 +10,24 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmpno(Long empno);
     Optional<User> findByEmail(String email);
 
-    // ✅ 로그인 시 user → userRoles → role, team 까지 즉시 로딩
-    @EntityGraph(attributePaths = {"userRoles", "userRoles.role", "userRoles.team"})
+    @EntityGraph(attributePaths = {
+            "userRoles",
+            "userRoles.role",
+            "userRoles.team"
+    })
     Optional<User> findWithRolesByEmpno(Long empno);
+
+    @EntityGraph(attributePaths = {
+            "userRoles",
+            "userRoles.role",
+            "userRoles.team"
+    })
+    Optional<User> findWithRolesById(Long id);
+
+    @EntityGraph(attributePaths = {
+            "userRoles",
+            "userRoles.role",
+            "userRoles.team"
+    })
+    Optional<User> findWithRolesByEmail(String email);
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/security/AuthUtil.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/security/AuthUtil.java
@@ -3,35 +3,42 @@ package com.cloudrangers.cloudpilot.security;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.Map;
-
 public class AuthUtil {
 
-    /** ✅ 현재 로그인한 사용자의 사번(empno) */
-    public static String getCurrentEmpno() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) return null;
-        return authentication.getName(); // empno
-    }
-
-    /** ✅ 현재 로그인한 사용자의 역할(role) */
-    public static String getCurrentRole() {
+    /** 내부에서 principal 가져오는 공통 메서드 */
+    private static CustomUserDetails getPrincipal() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || auth.getDetails() == null) return null;
-        if (!(auth.getDetails() instanceof Map)) return null;
-        return (String) ((Map<?, ?>) auth.getDetails()).get("role");
+        if (auth == null) return null;
+        if (!(auth.getPrincipal() instanceof CustomUserDetails)) return null;
+        return (CustomUserDetails) auth.getPrincipal();
     }
 
-    /** ✅ 현재 로그인한 사용자의 소속 팀(team) */
-    public static String getCurrentTeam() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || auth.getDetails() == null) return null;
-        if (!(auth.getDetails() instanceof Map)) return null;
-        return (String) ((Map<?, ?>) auth.getDetails()).get("team");
+    /** 🔥 현재 로그인한 사용자 userId */
+    public static Long getUserId() {
+        CustomUserDetails p = getPrincipal();
+        return p != null ? p.getUserId() : null;
     }
 
-    /** ✅ 로그인 여부 확인 */
+    /** 🔥 현재 로그인한 사용자 empno */
+    public static String getEmpno() {
+        CustomUserDetails p = getPrincipal();
+        return p != null ? p.getEmpno() : null;
+    }
+
+    /** 🔥 현재 로그인한 사용자 역할 (HEAD / LEADER / MEMBER) */
+    public static String getRole() {
+        CustomUserDetails p = getPrincipal();
+        return p != null ? p.getRole() : null;
+    }
+
+    /** 🔥 현재 로그인한 사용자 teamId */
+    public static Long getTeamId() {
+        CustomUserDetails p = getPrincipal();
+        return p != null ? p.getTeamId() : null;
+    }
+
+    /** 로그인 여부 */
     public static boolean isAuthenticated() {
-        return SecurityContextHolder.getContext().getAuthentication() != null;
+        return getPrincipal() != null;
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/security/CustomUserDetails.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/security/CustomUserDetails.java
@@ -1,0 +1,43 @@
+package com.cloudrangers.cloudpilot.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private Long userId;
+    private String empno;
+    private String role;
+    private Long teamId;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override
+    public String getPassword() { return null; }
+
+    @Override
+    public String getUsername() { return empno; }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/security/JwtAuthenticationFilter.java
@@ -13,13 +13,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
 
 @Slf4j
 @Component
@@ -43,9 +41,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         if (redisTemplate.hasKey("BLACKLIST:" + token)) {
-            log.warn("blacklisted token");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write("Token is blacklisted.");
+            response.getWriter().write("Token is blacklisted");
             return;
         }
 
@@ -54,13 +51,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 Claims claims = jwtProvider.parseClaims(token);
 
+                Long userId = claims.get("userId", Long.class);
                 String empno = claims.getSubject();
+                String role = claims.get("role", String.class);
+                Long teamId = claims.get("teamId", Long.class);
+
+                CustomUserDetails principal = new CustomUserDetails(userId, empno, role, teamId);
 
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(
-                                new User(empno, "", Collections.emptyList()),
+                                principal,
                                 null,
-                                Collections.emptyList()
+                                principal.getAuthorities()
                         );
 
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
@@ -69,19 +71,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
         } catch (JwtExpiredException e) {
-            log.warn("token expired");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.getWriter().write("Access token expired");
             return;
 
         } catch (JwtInvalidException e) {
-            log.warn("invalid token");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.getWriter().write("Invalid token");
             return;
 
         } catch (Exception e) {
-            log.error("filter error: {}", e.getMessage());
+            log.error("JWT filter error: {}", e.getMessage());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.getWriter().write("Invalid authorization");
             return;
@@ -97,8 +97,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return header.substring(7);
         }
 
-        if (request.getCookies() != null) {
-            for (Cookie cookie : request.getCookies()) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
                 if ("access_token".equals(cookie.getName())) {
                     return cookie.getValue();
                 }

--- a/src/main/java/com/cloudrangers/cloudpilot/security/JwtProvider.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/security/JwtProvider.java
@@ -4,9 +4,9 @@ import com.cloudrangers.cloudpilot.exception.jwt.JwtExpiredException;
 import com.cloudrangers.cloudpilot.exception.jwt.JwtInvalidException;
 import com.cloudrangers.cloudpilot.exception.jwt.JwtMissingSecretException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -60,8 +60,10 @@ public class JwtProvider {
                     .build()
                     .parseSignedClaims(token);
             return true;
+
         } catch (ExpiredJwtException e) {
             throw new JwtExpiredException();
+
         } catch (JwtException | IllegalArgumentException e) {
             throw new JwtInvalidException();
         }
@@ -74,8 +76,10 @@ public class JwtProvider {
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
+
         } catch (ExpiredJwtException e) {
             throw new JwtExpiredException();
+
         } catch (JwtException e) {
             throw new JwtInvalidException();
         }
@@ -89,19 +93,11 @@ public class JwtProvider {
         try {
             long now = System.currentTimeMillis();
             long exp = parseClaims(token).getExpiration().getTime();
-            return Math.max(exp - now, 0);
-        } catch (Exception e) {
-            return 0;
-        }
-    }
+            long remain = exp - now;
+            return remain > 1000 ? remain : 1000;  // 최소 1초 보장
 
-    public String generateTokenWithClaims(String subject, Map<String, Object> claims) {
-        return Jwts.builder()
-                .subject(subject)
-                .claims(claims)
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXP_MS))
-                .signWith(getSigningKey(), Jwts.SIG.HS256)
-                .compact();
+        } catch (Exception e) {
+            return 1000; // 최소 1초
+        }
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/security/PermissionChecker.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/security/PermissionChecker.java
@@ -1,0 +1,162 @@
+package com.cloudrangers.cloudpilot.security;
+
+import com.cloudrangers.cloudpilot.domain.user.User;
+import com.cloudrangers.cloudpilot.domain.user.UserRole;
+import com.cloudrangers.cloudpilot.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PermissionChecker {
+
+    private final UserRepository userRepository;
+
+    private UserRole highestRole(Long userId) {
+        User user = userRepository.findWithRolesById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found: " + userId));
+
+        return user.getUserRoles().stream()
+                .max(Comparator.comparingInt(
+                        ur -> Optional.ofNullable(ur.getRole().getPermissionLevel()).orElse(0)
+                ))
+                .orElseThrow(() -> new RuntimeException("No roles for userId=" + userId));
+    }
+
+    private Map<String, Object> rootPerms(UserRole ur) {
+        Map<String, Object> map = ur.getRole().getPermissions();
+        return map == null ? Map.of() : map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> subPerms(Map<String, Object> root, String key) {
+        Object raw = root.get(key);
+        if (raw instanceof Map<?, ?> rawMap) {
+            Map<String, Object> result = new HashMap<>();
+            rawMap.forEach((k, v) -> {
+                if (k != null) result.put(String.valueOf(k), v);
+            });
+            return result;
+        }
+        return Map.of();
+    }
+
+    private boolean flag(Map<String, Object> map, String key) {
+        Object v = map.get(key);
+        if (v instanceof Boolean b) return b;
+        if (v instanceof String s)
+            return "true".equalsIgnoreCase(s) || "1".equals(s);
+        return false;
+    }
+
+    private String normalizeScope(Object scopeObj) {
+        if (scopeObj == null) return "self_only";
+        String s = String.valueOf(scopeObj).trim().toLowerCase();
+        return switch (s) {
+            case "multi_team", "multi-team" -> "multi_team";
+            case "own_team", "own-team" -> "own_team";
+            case "self_only", "self-only", "self" -> "self_only";
+            case "system_all" -> "system_all";
+            default -> "self_only";
+        };
+    }
+
+    public boolean canViewVM(Long userId, Long vmTeamId, Long vmOwnerId) {
+        UserRole ur = highestRole(userId);
+        String roleCode = Optional.ofNullable(ur.getRole().getCode()).orElse("UNKNOWN");
+        Long userTeamId = ur.getTeam() != null ? ur.getTeam().getId() : null;
+
+        Map<String, Object> root = rootPerms(ur);
+        Map<String, Object> vm = subPerms(root, "vm");
+        String scope = normalizeScope(root.get("scope"));
+
+        boolean viewAll = flag(vm, "view_all");
+        boolean viewTeam = flag(vm, "view_team");
+        boolean viewSelf = flag(vm, "view_self");
+
+        if ("ADMIN".equalsIgnoreCase(roleCode) && "system_all".equals(scope)) return true;
+        if (viewAll) return true;
+        if (viewTeam && userTeamId != null && userTeamId.equals(vmTeamId)) return true;
+        if (viewSelf && userId != null && userId.equals(vmOwnerId)) return true;
+
+        return switch (scope) {
+            case "system_all" -> true;
+            case "multi_team" -> true;
+            case "own_team" -> userTeamId != null && userTeamId.equals(vmTeamId);
+            case "self_only" -> userId != null && userId.equals(vmOwnerId);
+            default -> false;
+        };
+    }
+
+    public boolean canApplyPackage(Long userId) {
+        UserRole ur = highestRole(userId);
+        Map<String, Object> root = rootPerms(ur);
+        Map<String, Object> pkg = subPerms(root, "package");
+        return flag(pkg, "apply");
+    }
+
+    public boolean canApproveL1(Long userId) {
+        UserRole ur = highestRole(userId);
+        Map<String, Object> root = rootPerms(ur);
+        Map<String, Object> pkg = subPerms(root, "package");
+        return flag(pkg, "approve_l1");
+    }
+
+    public boolean canApproveFinal(Long userId) {
+        UserRole ur = highestRole(userId);
+        Map<String, Object> root = rootPerms(ur);
+        Map<String, Object> pkg = subPerms(root, "package");
+        return flag(pkg, "approve_final");
+    }
+
+    public boolean canInstallPackage(Long userId, Long vmTeamId, Long vmOwnerId) {
+        UserRole ur = highestRole(userId);
+        String roleCode = Optional.ofNullable(ur.getRole().getCode()).orElse("UNKNOWN");
+        Long userTeamId = ur.getTeam() != null ? ur.getTeam().getId() : null;
+
+        Map<String, Object> root = rootPerms(ur);
+        Map<String, Object> pkg = subPerms(root, "package");
+        String scope = normalizeScope(root.get("scope"));
+
+        boolean canExecute = flag(pkg, "execute");
+        if (!canExecute) return false;
+        if ("ADMIN".equalsIgnoreCase(roleCode) && "system_all".equals(scope)) return true;
+
+        return switch (scope) {
+            case "system_all" -> true;
+            case "multi_team" -> true;
+            case "own_team" -> userTeamId != null && userTeamId.equals(vmTeamId);
+            case "self_only" -> userId != null && userId.equals(vmOwnerId);
+            default -> false;
+        };
+    }
+
+    public boolean canCreateVM(Long userId, Long targetTeamId) {
+        UserRole ur = highestRole(userId);
+        String roleCode = ur.getRole().getCode();
+        Long userTeamId = ur.getTeam() != null ? ur.getTeam().getId() : null;
+
+        Map<String, Object> root = rootPerms(ur);
+        Map<String, Object> vm = subPerms(root, "vm");
+        String scope = normalizeScope(root.get("scope"));
+
+        boolean create = flag(vm, "create");
+        if (!create) return false;
+        if ("ADMIN".equalsIgnoreCase(roleCode) && "system_all".equals(scope)) return true;
+
+        return switch (scope) {
+            case "system_all" -> true;
+            case "multi_team" -> true;
+            case "own_team" -> userTeamId != null && userTeamId.equals(targetTeamId);
+            case "self_only" -> false;
+            default -> false;
+        };
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/service/user/UserService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/user/UserService.java
@@ -14,6 +14,6 @@ public interface UserService {
     void changePassword(String currentPassword, String newPassword);
     void updateEmail(Long userId, String newEmail);
     Map<String, Object> buildClaims(String empno);
-    String refresh(String refreshToken);
 
+    String refresh(HttpServletRequest request);
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/user/UserServiceImpl.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/user/UserServiceImpl.java
@@ -35,7 +35,6 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, Object> redisTemplate;
 
-    /** 로그인 */
     @Override
     public LoginResponse login(@NonNull LoginRequest request) {
 
@@ -50,14 +49,7 @@ public class UserServiceImpl implements UserService {
         var role = userRole.getRole();
         var team = userRole.getTeam();
 
-        Map<String, Object> claims = buildClaims(String.valueOf(user.getEmpno()));
-
-        String accessToken = jwtProvider.generateAccessToken(String.valueOf(user.getEmpno()), claims);
-        String refreshToken = jwtProvider.generateRefreshToken(String.valueOf(user.getEmpno()));
-
         return LoginResponse.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
                 .username(user.getUsername())
                 .roleCode(role.getCode())
                 .roleName(role.getName())
@@ -66,12 +58,23 @@ public class UserServiceImpl implements UserService {
                 .build();
     }
 
-    /** refresh token → 새로운 access token */
     @Override
-    public String refresh(String refreshToken) {
+    public String refresh(HttpServletRequest request) {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw new InvalidTokenException("refresh_token 쿠키가 없습니다.");
+        }
+
+        String refreshToken = null;
+        for (Cookie cookie : cookies) {
+            if ("refresh_token".equals(cookie.getName())) {
+                refreshToken = cookie.getValue();
+            }
+        }
 
         if (refreshToken == null) {
-            throw new InvalidTokenException("리프레시 토큰이 없습니다.");
+            throw new InvalidTokenException("refresh_token 쿠키가 없습니다.");
         }
 
         if (redisTemplate.hasKey("BLACKLIST:" + refreshToken)) {
@@ -88,7 +91,6 @@ public class UserServiceImpl implements UserService {
         return jwtProvider.generateAccessToken(empno, claims);
     }
 
-    /** 로그아웃 */
     @Override
     public void logout(HttpServletRequest request) {
 
@@ -104,13 +106,16 @@ public class UserServiceImpl implements UserService {
 
         long expiration = jwtProvider.getRemainingExpiration(token);
 
-        redisTemplate.opsForValue().set("BLACKLIST:" + token, "logout",
-                expiration, TimeUnit.MILLISECONDS);
+        redisTemplate.opsForValue().set(
+                "BLACKLIST:" + token,
+                "logout",
+                expiration,
+                TimeUnit.MILLISECONDS
+        );
 
-        log.info("🚫 로그아웃 완료: {}", token);
+        log.info("로그아웃 완료: {}", token);
     }
 
-    /** 비밀번호 초기화 */
     @Override
     public void sendPasswordResetEmail(String email) {
 
@@ -119,12 +124,16 @@ public class UserServiceImpl implements UserService {
 
         String resetToken = UUID.randomUUID().toString();
 
-        redisTemplate.opsForValue().set("PWD_RESET_TOKEN:" + resetToken, email, 15, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(
+                "PWD_RESET_TOKEN:" + resetToken,
+                email,
+                15,
+                TimeUnit.MINUTES
+        );
 
-        log.info("📩 비밀번호 재설정 토큰 발급: {}", resetToken);
+        log.info("비밀번호 재설정 토큰 발급: {}", resetToken);
     }
 
-    /** 비밀번호 재설정 */
     @Override
     public void confirmPasswordReset(String token, String newPassword) {
 
@@ -142,10 +151,9 @@ public class UserServiceImpl implements UserService {
 
         redisTemplate.delete("PWD_RESET_TOKEN:" + token);
 
-        log.info("✅ 비밀번호 재설정 완료: {}", email);
+        log.info("비밀번호 재설정 완료: {}", email);
     }
 
-    /** 비밀번호 변경 */
     @Override
     public void changePassword(String currentPassword, String newPassword) {
 
@@ -163,10 +171,9 @@ public class UserServiceImpl implements UserService {
         user.setPasswordHash(passwordEncoder.encode(newPassword));
         userRepository.save(user);
 
-        log.info("🔑 비밀번호 변경 완료: {}", empno);
+        log.info("비밀번호 변경 완료: {}", empno);
     }
 
-    /** 공통 Claims 빌더 */
     @Override
     public Map<String, Object> buildClaims(String empno) {
 
@@ -178,6 +185,7 @@ public class UserServiceImpl implements UserService {
         var team = userRole.getTeam();
 
         Map<String, Object> claims = new HashMap<>();
+        claims.put("userId", user.getId());
         claims.put("role", role.getCode());
         claims.put("teamId", team != null ? team.getId() : null);
         claims.put("team", team != null ? team.getName() : "GLOBAL");
@@ -185,14 +193,12 @@ public class UserServiceImpl implements UserService {
         return claims;
     }
 
-    /** 역할 우선순위 계산 */
     private UserRole getHighestUserRole(User user) {
         return user.getUserRoles().stream()
                 .max(Comparator.comparingInt(a -> a.getRole().getPermissionLevel()))
                 .orElseThrow(() -> new RuntimeException("역할 정보가 없습니다."));
     }
 
-    /** Access token 추출 */
     private String extractTokenFromCookies(HttpServletRequest request) {
         if (request.getCookies() == null) return null;
         for (Cookie cookie : request.getCookies()) {
@@ -205,6 +211,6 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void updateEmail(Long userId, String newEmail) {
-        // TODO: 이메일 변경 로직
+        // TODO
     }
 }


### PR DESCRIPTION
📌 Summary

- JWT 기반 인증 구조 리팩토링

- 로그인 시 역할(Role) · 팀(Team) 정보 포함

- PermissionChecker 기반 VM/패키지 설치 권한 제어 추가

- 불필요한 Catalog/Provision 레거시 코드 정리

✍️ Description

- CustomUserDetails 추가 및 인증 모델 개선

- JwtAuthenticationFilter · JwtProvider 로직 정비

- UserService 로그인 응답에 role/team 정보 포함하도록 변경

- PermissionChecker로 MEMBER/LEADER/HEAD/ADMIN 권한 정책 구현

- 기존 Catalog/Provision 도메인 및 서비스 제거로 코드베이스 축소

- 관련 컨트롤러/서비스/레포지토리 일괄 삭제

close: #20

💡 PR Point

- 로그인 후 role/team 정보 정상 반영 여부

- PermissionChecker가 VM 및 패키지 설치권한을 정확히 제한하는지

- 대규모 레거시 제거 이후 빌드/런타임 이상 여부

- JWT 기반 인증 흐름 및 헤더·쿠키 처리 정상 여부

📚 Reference

- Spring Security CustomUserDetails

- JWT 인증 + RBAC(Role-Based Access Control) 구조