### PR TITLE
[feat] #27 - 패키지 요청 및 조회, 승인 기능

### DIFF
--- a/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
@@ -75,10 +75,9 @@ public class PkgRequestController {
     }
 
 
-
-    /** 5) [팀장] L1 승인/반려 */
+    /** 5) [팀장/부장 공통] 승인/반려 */
     @PostMapping("/requests/{requestId}/approve")
-    public ApiResponse<PkgRequestResponse> approveOrRejectL1(
+    public ApiResponse<PkgRequestResponse> approveOrReject(
             @PathVariable Long requestId,
             @RequestBody PkgApprovalActionRequest body
     ) {
@@ -86,23 +85,10 @@ public class PkgRequestController {
         if (approverId == null) {
             throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
         }
-        // 팀장 결재 처리
-        PkgRequestResponse res = packageService.handleL1Approval(requestId, approverId, body);
-        return ApiResponse.success(res);
-    }
 
-    /** 6) [부장] 최종 승인/반려 */
-    @PostMapping("/requests/{requestId}/approve")
-    public ApiResponse<PkgRequestResponse> approveOrRejectFinal(
-            @PathVariable Long requestId,
-            @RequestBody PkgApprovalActionRequest body
-    ) {
-        Long approverId = AuthUtil.getUserId();
-        if (approverId == null) {
-            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
-        }
-        // 부장 결재 처리
-        PkgRequestResponse res = packageService.handleFinalApproval(requestId, approverId, body);
+        PkgRequestResponse res =
+                packageService.approveOrReject(requestId, approverId, body);
+
         return ApiResponse.success(res);
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
@@ -1,0 +1,34 @@
+package com.cloudrangers.cloudpilot.controller;
+
+import com.cloudrangers.cloudpilot.common.ApiResponse;
+import com.cloudrangers.cloudpilot.dto.request.PkgRequestCreateRequest;
+import com.cloudrangers.cloudpilot.dto.response.PkgRequestResponse;
+import com.cloudrangers.cloudpilot.security.AuthUtil;
+import com.cloudrangers.cloudpilot.service.pkg.PackageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/packages")
+@RequiredArgsConstructor
+public class PkgRequestController {
+
+    private final PackageService packageService;
+
+    @PostMapping("/requests")
+    public ApiResponse<PkgRequestResponse> createRequest(
+            @RequestBody PkgRequestCreateRequest request
+    ) {
+        // JWT에서 userId 꺼냄
+        Long userId = AuthUtil.getUserId();
+
+        if (userId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+
+        // 서비스에 dto + userId 넘김
+        PkgRequestResponse response = packageService.createRequest(request, userId);
+
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
@@ -9,6 +9,7 @@ import com.cloudrangers.cloudpilot.service.pkg.PackageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import com.cloudrangers.cloudpilot.dto.response.PkgRequestDetailResponse;
+import jakarta.validation.Valid;
 
 
 import java.util.List;
@@ -23,7 +24,7 @@ public class PkgRequestController {
     /** 1) 패키지 설치 요청 생성 */
     @PostMapping("/requests")
     public ApiResponse<PkgRequestResponse> createRequest(
-            @RequestBody PkgRequestCreateRequest request
+            @RequestBody @Valid PkgRequestCreateRequest request
     ) {
         Long userId = AuthUtil.getUserId();
         if (userId == null) {
@@ -79,7 +80,7 @@ public class PkgRequestController {
     @PostMapping("/requests/{requestId}/approve")
     public ApiResponse<PkgRequestResponse> approveOrReject(
             @PathVariable Long requestId,
-            @RequestBody PkgApprovalActionRequest body
+            @RequestBody @Valid PkgApprovalActionRequest body
     ) {
         Long approverId = AuthUtil.getUserId();
         if (approverId == null) {

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
@@ -33,16 +33,6 @@ public class PkgRequestController {
         return ApiResponse.success(response);
     }
 
-    /** 2) [상태 확인] 내가 올린 모든 요청 (사원/팀장/부장 공통) */
-    @GetMapping("/requests/me")
-    public ApiResponse<List<PkgRequestResponse>> getMyRequests() {
-        Long userId = AuthUtil.getUserId();
-        if (userId == null) {
-            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
-        }
-        List<PkgRequestResponse> list = packageService.getMyRequests(userId);
-        return ApiResponse.success(list);
-    }
     /** 7) [상세조회] 단일 요청 + 승인/반려 이력까지 모두 반환 */
     @GetMapping("/requests/{requestId}")
     public ApiResponse<PkgRequestDetailResponse> getRequestDetail(
@@ -59,37 +49,36 @@ public class PkgRequestController {
         return ApiResponse.success(detail);
     }
 
-
-
-
-    /** 3) [상태 확인] 내가 결재한 이력 (팀장: L1, 부장: FINAL) */
-    @GetMapping("/requests/history/me")
-    public ApiResponse<List<PkgRequestResponse>> getMyApprovalHistory() {
+    @GetMapping("/requests")
+    public ApiResponse<List<PkgRequestResponse>> getRequests(
+            @RequestParam(name = "view", defaultValue = "my") String view
+    ) {
         Long userId = AuthUtil.getUserId();
         if (userId == null) {
             throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
         }
-        List<PkgRequestResponse> list = packageService.getMyApprovalHistory(userId);
+
+        List<PkgRequestResponse> list;
+
+        switch (view) {
+            case "my" ->       // 내가 올린 요청
+                    list = packageService.getMyRequests(userId);
+            case "history" ->  // 내가 결재한 이력
+                    list = packageService.getMyApprovalHistory(userId);
+            case "todo" ->     // 지금 내가 결재해야 하는 것들
+                    list = packageService.getMyTodoApprovals(userId);
+            default ->
+                    throw new IllegalArgumentException("지원하지 않는 view 값입니다: " + view);
+        }
+
         return ApiResponse.success(list);
     }
 
-    /** 4) [To-do] 지금 내가 결재해야 하는 요청 목록
-     *   - 팀장 : 우리 팀 pending
-     *   - 부장 : 전체 l1_approved
-     */
-    @GetMapping("/requests/todo")
-    public ApiResponse<List<PkgRequestResponse>> getMyTodoApprovals() {
-        Long userId = AuthUtil.getUserId();
-        if (userId == null) {
-            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
-        }
-        List<PkgRequestResponse> list = packageService.getMyTodoApprovals(userId);
-        return ApiResponse.success(list);
-    }
+
 
     /** 5) [팀장] L1 승인/반려 */
-    @PostMapping("/requests/{requestId}/l1")
-    public ApiResponse<PkgRequestResponse> handleL1Approval(
+    @PostMapping("/requests/{requestId}/approve")
+    public ApiResponse<PkgRequestResponse> approveOrRejectL1(
             @PathVariable Long requestId,
             @RequestBody PkgApprovalActionRequest body
     ) {
@@ -97,14 +86,14 @@ public class PkgRequestController {
         if (approverId == null) {
             throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
         }
-        PkgRequestResponse res =
-                packageService.handleL1Approval(requestId, approverId, body);
+        // 팀장 결재 처리
+        PkgRequestResponse res = packageService.handleL1Approval(requestId, approverId, body);
         return ApiResponse.success(res);
     }
 
     /** 6) [부장] 최종 승인/반려 */
-    @PostMapping("/requests/{requestId}/final")
-    public ApiResponse<PkgRequestResponse> handleFinalApproval(
+    @PostMapping("/requests/{requestId}/approve")
+    public ApiResponse<PkgRequestResponse> approveOrRejectFinal(
             @PathVariable Long requestId,
             @RequestBody PkgApprovalActionRequest body
     ) {
@@ -112,8 +101,8 @@ public class PkgRequestController {
         if (approverId == null) {
             throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
         }
-        PkgRequestResponse res =
-                packageService.handleFinalApproval(requestId, approverId, body);
+        // 부장 결재 처리
+        PkgRequestResponse res = packageService.handleFinalApproval(requestId, approverId, body);
         return ApiResponse.success(res);
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/PkgRequestController.java
@@ -1,12 +1,17 @@
 package com.cloudrangers.cloudpilot.controller;
 
 import com.cloudrangers.cloudpilot.common.ApiResponse;
+import com.cloudrangers.cloudpilot.dto.request.PkgApprovalActionRequest;
 import com.cloudrangers.cloudpilot.dto.request.PkgRequestCreateRequest;
 import com.cloudrangers.cloudpilot.dto.response.PkgRequestResponse;
 import com.cloudrangers.cloudpilot.security.AuthUtil;
 import com.cloudrangers.cloudpilot.service.pkg.PackageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import com.cloudrangers.cloudpilot.dto.response.PkgRequestDetailResponse;
+
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/packages")
@@ -15,20 +20,100 @@ public class PkgRequestController {
 
     private final PackageService packageService;
 
+    /** 1) 패키지 설치 요청 생성 */
     @PostMapping("/requests")
     public ApiResponse<PkgRequestResponse> createRequest(
             @RequestBody PkgRequestCreateRequest request
     ) {
-        // JWT에서 userId 꺼냄
         Long userId = AuthUtil.getUserId();
+        if (userId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+        PkgRequestResponse response = packageService.createRequest(request, userId);
+        return ApiResponse.success(response);
+    }
 
+    /** 2) [상태 확인] 내가 올린 모든 요청 (사원/팀장/부장 공통) */
+    @GetMapping("/requests/me")
+    public ApiResponse<List<PkgRequestResponse>> getMyRequests() {
+        Long userId = AuthUtil.getUserId();
+        if (userId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+        List<PkgRequestResponse> list = packageService.getMyRequests(userId);
+        return ApiResponse.success(list);
+    }
+    /** 7) [상세조회] 단일 요청 + 승인/반려 이력까지 모두 반환 */
+    @GetMapping("/requests/{requestId}")
+    public ApiResponse<PkgRequestDetailResponse> getRequestDetail(
+            @PathVariable Long requestId
+    ) {
+        Long userId = AuthUtil.getUserId();
         if (userId == null) {
             throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
         }
 
-        // 서비스에 dto + userId 넘김
-        PkgRequestResponse response = packageService.createRequest(request, userId);
+        PkgRequestDetailResponse detail =
+                packageService.getRequestDetail(requestId, userId);
 
-        return ApiResponse.success(response);
+        return ApiResponse.success(detail);
+    }
+
+
+
+
+    /** 3) [상태 확인] 내가 결재한 이력 (팀장: L1, 부장: FINAL) */
+    @GetMapping("/requests/history/me")
+    public ApiResponse<List<PkgRequestResponse>> getMyApprovalHistory() {
+        Long userId = AuthUtil.getUserId();
+        if (userId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+        List<PkgRequestResponse> list = packageService.getMyApprovalHistory(userId);
+        return ApiResponse.success(list);
+    }
+
+    /** 4) [To-do] 지금 내가 결재해야 하는 요청 목록
+     *   - 팀장 : 우리 팀 pending
+     *   - 부장 : 전체 l1_approved
+     */
+    @GetMapping("/requests/todo")
+    public ApiResponse<List<PkgRequestResponse>> getMyTodoApprovals() {
+        Long userId = AuthUtil.getUserId();
+        if (userId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+        List<PkgRequestResponse> list = packageService.getMyTodoApprovals(userId);
+        return ApiResponse.success(list);
+    }
+
+    /** 5) [팀장] L1 승인/반려 */
+    @PostMapping("/requests/{requestId}/l1")
+    public ApiResponse<PkgRequestResponse> handleL1Approval(
+            @PathVariable Long requestId,
+            @RequestBody PkgApprovalActionRequest body
+    ) {
+        Long approverId = AuthUtil.getUserId();
+        if (approverId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+        PkgRequestResponse res =
+                packageService.handleL1Approval(requestId, approverId, body);
+        return ApiResponse.success(res);
+    }
+
+    /** 6) [부장] 최종 승인/반려 */
+    @PostMapping("/requests/{requestId}/final")
+    public ApiResponse<PkgRequestResponse> handleFinalApproval(
+            @PathVariable Long requestId,
+            @RequestBody PkgApprovalActionRequest body
+    ) {
+        Long approverId = AuthUtil.getUserId();
+        if (approverId == null) {
+            throw new RuntimeException("인증 정보가 없습니다. 로그인 후 다시 시도해주세요.");
+        }
+        PkgRequestResponse res =
+                packageService.handleFinalApproval(requestId, approverId, body);
+        return ApiResponse.success(res);
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/pipeline/Job.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/pipeline/Job.java
@@ -16,7 +16,7 @@ import java.time.Instant;
         })
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
-public class Job {
+public class  Job {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgApproval.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgApproval.java
@@ -1,0 +1,53 @@
+package com.cloudrangers.cloudpilot.domain.pkg;
+
+import com.cloudrangers.cloudpilot.domain.user.User;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalResult;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalStep;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "pkg_approval",
+        indexes = {
+                @Index(name = "idx_pkg_approval_request", columnList = "pkg_request_id"),
+                @Index(name = "idx_pkg_approval_approver", columnList = "approver_user_id")
+        })
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PkgApproval {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 요청에 대한 승인인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pkg_request_id", nullable = false)
+    private PkgRequest pkgRequest;
+
+    // L1 / FINAL
+    @Enumerated(EnumType.STRING)
+    @Column(name = "step", nullable = false, length = 10)
+    private PkgApprovalStep step;
+
+    // 승인자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "approver_user_id", nullable = false)
+    private User approver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "result", nullable = false, length = 20)
+    private PkgApprovalResult result;
+
+    @Column(name = "decided_at", nullable = false)
+    private Instant decidedAt;
+
+    @PrePersist
+    void onCreate() {
+        if (decidedAt == null) decidedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgApproval.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgApproval.java
@@ -46,6 +46,9 @@ public class PkgApproval {
     @Column(name = "decided_at", nullable = false)
     private Instant decidedAt;
 
+    @Column(name = "description")
+    private String description;
+
     @PrePersist
     void onCreate() {
         if (decidedAt == null) decidedAt = Instant.now();

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgRequest.java
@@ -5,6 +5,7 @@ import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
+
 import java.time.Instant;
 
 @Entity

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/pkg/PkgRequest.java
@@ -1,0 +1,55 @@
+package com.cloudrangers.cloudpilot.domain.pkg;
+
+import com.cloudrangers.cloudpilot.domain.user.User;
+import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "pkg_request",
+        indexes = {
+                @Index(name = "idx_pkg_request_requested_by", columnList = "requested_by"),
+                @Index(name = "idx_pkg_request_status", columnList = "status")
+        })
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PkgRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 요청한 사람
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requested_by", nullable = false)
+    private User requestedBy;
+
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private Instant requestedAt;
+
+    @Column(name = "package_name", nullable = false, length = 200)
+    private String packageName;
+
+    @Column(name = "package_ver", nullable = false, length = 20)
+    private String packageVer;
+
+    @Column(name = "description")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PkgRequestStatus status;
+
+    @Column(name = "decided_at")
+    private Instant decidedAt;
+
+    @PrePersist
+    void onCreate() {
+        if (requestedAt == null) requestedAt = Instant.now();
+        if (status == null) status = PkgRequestStatus.pending;
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgApprovalActionRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgApprovalActionRequest.java
@@ -1,0 +1,18 @@
+package com.cloudrangers.cloudpilot.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 패키지 승인/반려 시 사용하는 요청 바디
+ * action: "approve" 또는 "reject"
+ */
+@Getter
+@Setter
+public class PkgApprovalActionRequest {
+    @NotBlank
+    private String action;  // approve / reject
+    private String reason;  // 승인/반려 사유
+}
+

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgApprovalActionRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgApprovalActionRequest.java
@@ -12,6 +12,8 @@ import lombok.Setter;
 @Setter
 public class PkgApprovalActionRequest {
     @NotBlank
+    private String step;
+    @NotBlank
     private String action;  // approve / reject
     private String reason;  // 승인/반려 사유
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgRequestCreateRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgRequestCreateRequest.java
@@ -1,0 +1,17 @@
+package com.cloudrangers.cloudpilot.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class PkgRequestCreateRequest {
+
+    @NotBlank
+    private String packageName;
+
+    @NotBlank
+    private String packageVer;
+
+    private String description;
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgRequestCreateRequest.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/request/PkgRequestCreateRequest.java
@@ -9,7 +9,6 @@ public class PkgRequestCreateRequest {
 
     @NotBlank
     private String packageName;
-
     @NotBlank
     private String packageVer;
 

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/response/PkgApprovalHistoryResponse.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/response/PkgApprovalHistoryResponse.java
@@ -1,0 +1,35 @@
+package com.cloudrangers.cloudpilot.dto.response;
+
+import com.cloudrangers.cloudpilot.domain.pkg.PkgApproval;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalResult;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalStep;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class PkgApprovalHistoryResponse {
+
+    private Long id;                // approval row id
+    private PkgApprovalStep step;   // L1 / FINAL
+    private PkgApprovalResult result; // approved / rejected
+    private String description;     // 승인/반려 사유
+    private Instant decidedAt;      // 결정 시각
+
+    private Long approverId;        // 승인자 user id
+    private String approverName;    // 승인자 이름 (username 기준)
+
+    public static PkgApprovalHistoryResponse from(PkgApproval entity) {
+        return PkgApprovalHistoryResponse.builder()
+                .id(entity.getId())
+                .step(entity.getStep())
+                .result(entity.getResult())
+                .description(entity.getDescription())
+                .decidedAt(entity.getDecidedAt())
+                .approverId(entity.getApprover().getId())
+                .approverName(entity.getApprover().getUsername())
+                .build();
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/response/PkgRequestDetailResponse.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/response/PkgRequestDetailResponse.java
@@ -1,0 +1,28 @@
+package com.cloudrangers.cloudpilot.dto.response;
+
+import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PkgRequestDetailResponse {
+
+    // 기존 PkgRequestResponse 내용(요청 기본 정보)
+    private PkgRequestResponse request;
+
+    // 승인/반려 이력 목록
+    private List<PkgApprovalHistoryResponse> approvals;
+
+    public static PkgRequestDetailResponse of(
+            PkgRequest request,
+            List<PkgApprovalHistoryResponse> approvals
+    ) {
+        return PkgRequestDetailResponse.builder()
+                .request(PkgRequestResponse.from(request))
+                .approvals(approvals)
+                .build();
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/response/PkgRequestResponse.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/response/PkgRequestResponse.java
@@ -1,0 +1,34 @@
+package com.cloudrangers.cloudpilot.dto.response;
+
+import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
+import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class PkgRequestResponse {
+    private Long id;
+    private String packageName;
+    private String packageVer;
+    private String description;
+    private PkgRequestStatus status;
+    private Instant requestedAt;
+    private Instant decidedAt;
+    private Long requestedBy;
+
+    public static PkgRequestResponse from(PkgRequest entity) {
+        return PkgRequestResponse.builder()
+                .id(entity.getId())
+                .packageName(entity.getPackageName())
+                .packageVer(entity.getPackageVer())
+                .description(entity.getDescription())
+                .status(entity.getStatus())
+                .requestedAt(entity.getRequestedAt())
+                .decidedAt(entity.getDecidedAt())
+                .requestedBy(entity.getRequestedBy().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/enums/PkgApprovalResult.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/enums/PkgApprovalResult.java
@@ -1,0 +1,10 @@
+package com.cloudrangers.cloudpilot.enums;
+
+/**
+ * pkg_approval.result 와 매핑
+ * DB enum: ('approved','rejected')
+ */
+public enum PkgApprovalResult {
+    approved,
+    rejected
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/enums/PkgApprovalStep.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/enums/PkgApprovalStep.java
@@ -1,0 +1,11 @@
+package com.cloudrangers.cloudpilot.enums;
+
+/**
+ * pkg_approval.step 과 매핑
+ * DB enum: ('L1','FINAL')
+ */
+public enum PkgApprovalStep {
+    L1,
+    FINAL
+}
+

--- a/src/main/java/com/cloudrangers/cloudpilot/enums/PkgRequestStatus.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/enums/PkgRequestStatus.java
@@ -1,0 +1,13 @@
+package com.cloudrangers.cloudpilot.enums;
+
+/**
+ * pkg_request.status 와 1:1 매핑
+ * DB enum: ('pending','l1_approved','approved','rejected')
+ */
+public enum PkgRequestStatus {
+    pending,
+    l1_approved,
+    approved,
+    rejected
+}
+

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PackageRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PackageRepository.java
@@ -1,4 +1,0 @@
-package com.cloudrangers.cloudpilot.repository.pkg;
-
-public class PackageRepository {
-}

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgApprovalRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgApprovalRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 public interface PkgApprovalRepository extends JpaRepository<PkgApproval, Long> {
 
-    List<PkgApproval> findByPkgRequest(PkgRequest request);
-
-    Optional<PkgApproval> findFirstByPkgRequestAndStep(PkgRequest request, PkgApprovalStep step);
+    List<PkgApproval> findByApprover_IdAndStep(Long approverId, PkgApprovalStep step);
+    List<PkgApproval> findByPkgRequest_IdOrderByDecidedAtAsc(Long requestId);
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgApprovalRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgApprovalRepository.java
@@ -1,0 +1,16 @@
+package com.cloudrangers.cloudpilot.repository.pkg;
+
+import com.cloudrangers.cloudpilot.domain.pkg.PkgApproval;
+import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalStep;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PkgApprovalRepository extends JpaRepository<PkgApproval, Long> {
+
+    List<PkgApproval> findByPkgRequest(PkgRequest request);
+
+    Optional<PkgApproval> findFirstByPkgRequestAndStep(PkgRequest request, PkgApprovalStep step);
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgRequestRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgRequestRepository.java
@@ -1,0 +1,14 @@
+package com.cloudrangers.cloudpilot.repository.pkg;
+
+import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
+import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PkgRequestRepository extends JpaRepository<PkgRequest, Long> {
+
+    List<PkgRequest> findByStatus(PkgRequestStatus status);
+
+    List<PkgRequest> findByRequestedBy_Id(Long userId);
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgRequestRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgRequestRepository.java
@@ -3,12 +3,47 @@ package com.cloudrangers.cloudpilot.repository.pkg;
 import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
 import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PkgRequestRepository extends JpaRepository<PkgRequest, Long> {
 
+    // 1) 내가 올린 요청들 (정렬 없이)
+    List<PkgRequest> findByRequestedBy_Id(Long userId);
+
+    // 2) 내가 올린 요청들 (최신순)
+    List<PkgRequest> findByRequestedBy_IdOrderByRequestedAtDesc(Long userId);
+
+    // 3) 상태로만 필터
     List<PkgRequest> findByStatus(PkgRequestStatus status);
 
-    List<PkgRequest> findByRequestedBy_Id(Long userId);
+    List<PkgRequest> findByStatusOrderByRequestedAtDesc(PkgRequestStatus status);
+
+    /**
+     * 팀장용 To-do 목록
+     *  - 내 팀(teamId)의 구성원들이 올린 pending 요청만 조회
+     */
+    @Query("""
+           SELECT pr
+           FROM PkgRequest pr
+           WHERE pr.status = :status
+             AND pr.requestedBy.id IN (
+                SELECT ur.user.id
+                FROM UserRole ur
+                WHERE ur.team.id = :teamId
+           )
+           ORDER BY pr.requestedAt DESC
+           """)
+    List<PkgRequest> findTeamPendingRequests(
+            @Param("teamId") Long teamId,
+            @Param("status") PkgRequestStatus status
+    );
+
+    /**
+     * 부장(HEAD)용 To-do 목록
+     *  - 상태 여러 개로 필터 (예: [PENDING, L1_APPROVED])
+     */
+    List<PkgRequest> findByStatusInOrderByRequestedAtDesc(List<PkgRequestStatus> statuses);
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgRequestRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pkg/PkgRequestRepository.java
@@ -3,9 +3,11 @@ package com.cloudrangers.cloudpilot.repository.pkg;
 import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
 import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 
 public interface PkgRequestRepository extends JpaRepository<PkgRequest, Long> {
@@ -40,6 +42,22 @@ public interface PkgRequestRepository extends JpaRepository<PkgRequest, Long> {
             @Param("teamId") Long teamId,
             @Param("status") PkgRequestStatus status
     );
+    @Modifying
+    @Query("""
+       UPDATE PkgRequest p
+          SET p.status = :newStatus,
+              p.decidedAt = :decidedAt
+        WHERE p.id = :id
+          AND p.status = :expectedStatus
+       """)
+    int updateStatusIfMatches(
+            @Param("id") Long id,
+            @Param("expectedStatus") PkgRequestStatus expectedStatus,
+            @Param("newStatus") PkgRequestStatus newStatus,
+            @Param("decidedAt") Instant decidedAt
+    );
+
+
 
     /**
      * 부장(HEAD)용 To-do 목록

--- a/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
@@ -125,15 +125,24 @@ public class PackageService {
      *  - reason: 승인/거절 사유 (pkg_approval.description에 저장)
      */
     @Transactional
-    public PkgRequestResponse approveOrReject(Long requestId, Long approverId, PkgApprovalActionRequest body) {
-        String step = body.getStep(); // "L1" or "FINAL"
-        if ("L1".equalsIgnoreCase(step)) {
-            return handleL1Approval(requestId, approverId, body);
-        } else if ("FINAL".equalsIgnoreCase(step)) {
+    public PkgRequestResponse approveOrReject(
+            Long requestId,
+            Long approverId,
+            PkgApprovalActionRequest body
+    ) {
+
+        // 부장 권한이 있으면 FINAL 처리
+        if (permissionChecker.canApproveFinal(approverId)) {
             return handleFinalApproval(requestId, approverId, body);
-        } else {
-            throw new IllegalArgumentException("Invalid step: " + step);
         }
+
+        // 팀장 권한이 있으면 L1 처리
+        if (permissionChecker.canApproveL1(approverId)) {
+            return handleL1Approval(requestId, approverId, body);
+        }
+
+        // 둘 다 아니면 권한 없음
+        throw new IllegalStateException("User has no approval permission: " + approverId);
     }
     @Transactional
     public PkgRequestResponse handleL1Approval(Long requestId, Long approverId, PkgApprovalActionRequest body) {

--- a/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
@@ -3,7 +3,9 @@ package com.cloudrangers.cloudpilot.service.pkg;
 import com.cloudrangers.cloudpilot.domain.pkg.PkgApproval;
 import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
 import com.cloudrangers.cloudpilot.domain.user.User;
+import com.cloudrangers.cloudpilot.dto.request.PkgApprovalActionRequest;
 import com.cloudrangers.cloudpilot.dto.request.PkgRequestCreateRequest;
+import com.cloudrangers.cloudpilot.dto.response.PkgRequestDetailResponse;
 import com.cloudrangers.cloudpilot.dto.response.PkgRequestResponse;
 import com.cloudrangers.cloudpilot.enums.PkgApprovalResult;
 import com.cloudrangers.cloudpilot.enums.PkgApprovalStep;
@@ -17,8 +19,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+// 추가 import
+import com.cloudrangers.cloudpilot.domain.user.UserRole;
+import com.cloudrangers.cloudpilot.repository.user.UserRoleRepository;
+import com.cloudrangers.cloudpilot.dto.response.PkgApprovalHistoryResponse;
+
 
 import java.time.Instant;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -28,27 +36,41 @@ public class PackageService {
     private final PkgRequestRepository pkgRequestRepository;
     private final PkgApprovalRepository pkgApprovalRepository;
     private final UserRepository userRepository;
+    private final UserRoleRepository userRoleRepository;
     private final PermissionChecker permissionChecker;
 
-    // 1) 패키지 설치 요청 생성
+    /**
+     * 1) 패키지 설치 요청 생성
+     *
+     * - 일반 사용자: status = pending
+     * - 팀장(L1 승인 권한 있는 사용자): status = l1_approved 로 바로 저장
+     * - 부장(L2 승인 권한 있는 사용자): status = approved (+pkg_approval FINAL 이력도 저장)
+     */
     @Transactional
     public PkgRequestResponse createRequest(PkgRequestCreateRequest reqDto, Long requesterId) {
 
-        // 1. 요청한 사용자 찾기
+        // 1. 요청자 조회
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + requesterId));
 
-        // 2. 이 사람이 "팀장 권한(L1 승인 가능)"인지 확인
-        //    - 팀장이면: 요청 넣자마자 L1 승인된 상태로 저장
-        //    - 팀장이 아니면: 그냥 pending 상태로 저장
+        // 2. 이 유저의 권한에 따라 기본 상태 결정
         PkgRequestStatus initialStatus;
-        if (permissionChecker.canApproveL1(requesterId)) {
+
+        boolean isFinalApprover = permissionChecker.canApproveFinal(requesterId);
+        boolean isL1Approver    = permissionChecker.canApproveL1(requesterId);
+
+        if (isFinalApprover) {
+            // 🔹 부장(HEAD) 이면 바로 최종 승인 상태로
+            initialStatus = PkgRequestStatus.approved;
+        } else if (isL1Approver) {
+            // 🔹 팀장(L1) 이면 L1 승인된 상태로
             initialStatus = PkgRequestStatus.l1_approved;
         } else {
+            // 🔹 일반 유저는 pending
             initialStatus = PkgRequestStatus.pending;
         }
 
-        // 3. 요청 엔티티 생성
+        // 3. pkg_request 엔터티 생성
         PkgRequest request = PkgRequest.builder()
                 .requestedBy(requester)
                 .packageName(reqDto.getPackageName())
@@ -62,13 +84,49 @@ public class PackageService {
         log.info("Created pkg_request id={} by user={}, initialStatus={}",
                 saved.getId(), requesterId, initialStatus);
 
+        // 5. 만약 부장이 직접 신청해서 바로 최종 승인된 경우 → 승인 이력도 남기고 싶으면 여기서 처리
+        if (isFinalApprover) {
+            PkgApproval autoApproval = PkgApproval.builder()
+                    .pkgRequest(saved)
+                    .step(PkgApprovalStep.FINAL)
+                    .approver(requester)
+                    .result(PkgApprovalResult.approved)
+                    .description(saved.getDescription())   // ⭐ 요청자가 적은 description 사용
+                    .decidedAt(Instant.now())
+                    .build();
+
+            pkgApprovalRepository.save(autoApproval);
+
+            saved.setDecidedAt(Instant.now());
+            pkgRequestRepository.save(saved);
+        }
+
+        // 6. 팀장인데 부장은 아닌 경우: L1 승인 이력 자동 생성
+        if (!isFinalApprover && isL1Approver) {
+            PkgApproval autoL1 = PkgApproval.builder()
+                    .pkgRequest(saved)
+                    .step(PkgApprovalStep.L1)
+                    .approver(requester)
+                    .result(PkgApprovalResult.approved)
+                    // 🔥 승인 사유도 요청 description 그대로
+                    .description(saved.getDescription())
+                    .decidedAt(Instant.now())
+                    .build();
+            pkgApprovalRepository.save(autoL1);
+        }
+
+
         return PkgRequestResponse.from(saved);
     }
 
-    // === 아래 L1/FINAL 승인/거절 메서드는 그대로 두면 됨 ===
-
+    /**
+     * 2) L1 승인/거절 공통 처리
+     *  - action: "approve" or "reject"
+     *  - reason: 승인/거절 사유 (pkg_approval.description에 저장)
+     */
     @Transactional
-    public PkgRequestResponse approveL1(Long requestId, Long approverId) {
+    public PkgRequestResponse handleL1Approval(Long requestId, Long approverId, PkgApprovalActionRequest body) {
+
         if (!permissionChecker.canApproveL1(approverId)) {
             throw new IllegalStateException("L1 approval not allowed for user=" + approverId);
         }
@@ -76,117 +134,286 @@ public class PackageService {
         PkgRequest request = getRequestOrThrow(requestId);
 
         if (request.getStatus() != PkgRequestStatus.pending) {
-            throw new IllegalStateException("Only pending requests can be L1-approved");
+            throw new IllegalStateException("Only pending requests can be L1-approved or rejected");
         }
 
         User approver = userRepository.findById(approverId)
                 .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
 
-        PkgApproval approval = PkgApproval.builder()
-                .pkgRequest(request)
-                .step(PkgApprovalStep.L1)
-                .approver(approver)
-                .result(PkgApprovalResult.approved)
-                .build();
-        pkgApprovalRepository.save(approval);
+        String action = body.getAction();
+        String reason = body.getReason(); // nullable 일 수 있음
 
-        request.setStatus(PkgRequestStatus.l1_approved);
-        pkgRequestRepository.save(request);
+        if ("approve".equalsIgnoreCase(action)) {
+            // 🔹 L1 승인
+            PkgApproval approval = PkgApproval.builder()
+                    .pkgRequest(request)                 // ✅ 빌더 메서드로 설정 (필드 직접 접근 X)
+                    .step(PkgApprovalStep.L1)
+                    .approver(approver)
+                    .result(PkgApprovalResult.approved)
+                    .description(reason)                 // 승인/거절 사유
+                    .decidedAt(Instant.now())
+                    .build();
+            pkgApprovalRepository.save(approval);
+
+            request.setStatus(PkgRequestStatus.l1_approved);
+            pkgRequestRepository.save(request);
+
+        } else if ("reject".equalsIgnoreCase(action)) {
+            // 🔹 L1 거절
+            PkgApproval approval = PkgApproval.builder()
+                    .pkgRequest(request)
+                    .step(PkgApprovalStep.L1)
+                    .approver(approver)
+                    .result(PkgApprovalResult.rejected)
+                    .description(reason)
+                    .decidedAt(Instant.now())
+                    .build();
+            pkgApprovalRepository.save(approval);
+
+            request.setStatus(PkgRequestStatus.rejected);
+            request.setDecidedAt(Instant.now());
+            pkgRequestRepository.save(request);
+
+        } else {
+            throw new IllegalArgumentException("Invalid action for L1: " + action);
+        }
 
         return PkgRequestResponse.from(request);
     }
 
+    /**
+     * 3) FINAL(부장) 승인/거절 공통 처리
+     */
     @Transactional
-    public PkgRequestResponse rejectL1(Long requestId, Long approverId) {
-        if (!permissionChecker.canApproveL1(approverId)) {
-            throw new IllegalStateException("L1 approval not allowed for user=" + approverId);
-        }
+    public PkgRequestResponse handleFinalApproval(Long requestId, Long approverId, PkgApprovalActionRequest body) {
 
-        PkgRequest request = getRequestOrThrow(requestId);
-
-        if (request.getStatus() != PkgRequestStatus.pending) {
-            throw new IllegalStateException("Only pending requests can be rejected at L1");
-        }
-
-        User approver = userRepository.findById(approverId)
-                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
-
-        PkgApproval approval = PkgApproval.builder()
-                .pkgRequest(request)
-                .step(PkgApprovalStep.L1)
-                .approver(approver)
-                .result(PkgApprovalResult.rejected)
-                .build();
-        pkgApprovalRepository.save(approval);
-
-        request.setStatus(PkgRequestStatus.rejected);
-        request.setDecidedAt(Instant.now());
-        pkgRequestRepository.save(request);
-
-        return PkgRequestResponse.from(request);
-    }
-
-    @Transactional
-    public PkgRequestResponse approveFinal(Long requestId, Long approverId) {
         if (!permissionChecker.canApproveFinal(approverId)) {
             throw new IllegalStateException("Final approval not allowed for user=" + approverId);
         }
 
         PkgRequest request = getRequestOrThrow(requestId);
 
-        if (request.getStatus() != PkgRequestStatus.l1_approved &&
-                request.getStatus() != PkgRequestStatus.pending) {
-            throw new IllegalStateException("Only pending or l1_approved requests can be finally approved");
+        if (request.getStatus() != PkgRequestStatus.l1_approved
+                && request.getStatus() != PkgRequestStatus.pending) {
+            throw new IllegalStateException("Only pending or l1_approved can be finally approved/rejected");
         }
 
         User approver = userRepository.findById(approverId)
                 .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
 
-        PkgApproval approval = PkgApproval.builder()
-                .pkgRequest(request)
-                .step(PkgApprovalStep.FINAL)
-                .approver(approver)
-                .result(PkgApprovalResult.approved)
-                .build();
-        pkgApprovalRepository.save(approval);
+        String action = body.getAction();
+        String reason = body.getReason();
 
-        request.setStatus(PkgRequestStatus.approved);
-        request.setDecidedAt(Instant.now());
-        pkgRequestRepository.save(request);
+        if ("approve".equalsIgnoreCase(action)) {
+            // 🔹 FINAL 승인
+            PkgApproval approval = PkgApproval.builder()
+                    .pkgRequest(request)
+                    .step(PkgApprovalStep.FINAL)
+                    .approver(approver)
+                    .result(PkgApprovalResult.approved)
+                    .description(reason)
+                    .decidedAt(Instant.now())
+                    .build();
+            pkgApprovalRepository.save(approval);
+
+            request.setStatus(PkgRequestStatus.approved);
+            request.setDecidedAt(Instant.now());
+            pkgRequestRepository.save(request);
+
+            // TODO: 여기서 ans_run 만들어서 실제 Ansible 설치 작업 트리거
+            // ex) ansibleService.triggerInstall(request);
+
+        } else if ("reject".equalsIgnoreCase(action)) {
+            // 🔹 FINAL 거절
+            if (request.getStatus() == PkgRequestStatus.rejected) {
+                throw new IllegalStateException("Already rejected");
+            }
+
+            PkgApproval approval = PkgApproval.builder()
+                    .pkgRequest(request)
+                    .step(PkgApprovalStep.FINAL)
+                    .approver(approver)
+                    .result(PkgApprovalResult.rejected)
+                    .description(reason)
+                    .decidedAt(Instant.now())
+                    .build();
+            pkgApprovalRepository.save(approval);
+
+            request.setStatus(PkgRequestStatus.rejected);
+            request.setDecidedAt(Instant.now());
+            pkgRequestRepository.save(request);
+
+        } else {
+            throw new IllegalArgumentException("Invalid action for FINAL: " + action);
+        }
 
         return PkgRequestResponse.from(request);
     }
+    @Transactional(readOnly = true)
+    public List<PkgRequestResponse> getPendingRequestsByTeam(Long teamId) {
+        // 팀 단위의 pending 요청들 조회 (팀장 화면 등에서 사용)
+        List<PkgRequest> list = pkgRequestRepository.findTeamPendingRequests(
+                teamId,
+                PkgRequestStatus.pending
+        );
 
-    @Transactional
-    public PkgRequestResponse rejectFinal(Long requestId, Long approverId) {
-        if (!permissionChecker.canApproveFinal(approverId)) {
-            throw new IllegalStateException("Final approval not allowed for user=" + approverId);
-        }
-
-        PkgRequest request = getRequestOrThrow(requestId);
-
-        if (request.getStatus() == PkgRequestStatus.rejected) {
-            throw new IllegalStateException("Already rejected");
-        }
-
-        User approver = userRepository.findById(approverId)
-                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
-
-        PkgApproval approval = PkgApproval.builder()
-                .pkgRequest(request)
-                .step(PkgApprovalStep.FINAL)
-                .approver(approver)
-                .result(PkgApprovalResult.rejected)
-                .build();
-        pkgApprovalRepository.save(approval);
-
-        request.setStatus(PkgRequestStatus.rejected);
-        request.setDecidedAt(Instant.now());
-        pkgRequestRepository.save(request);
-
-        return PkgRequestResponse.from(request);
+        return list.stream()
+                .map(PkgRequestResponse::from)
+                .toList();
     }
 
+    // 1) 내가 올린 요청들
+    @Transactional(readOnly = true)
+    public List<PkgRequestResponse> getMyRequests(Long userId) {
+        List<PkgRequest> list = pkgRequestRepository.findByRequestedBy_Id(userId);
+        return list.stream().map(PkgRequestResponse::from).toList();
+    }
+    /**
+     * 🔍 패키지 요청 1건 상세 조회
+     * - 일반유저 : 자기 요청만
+     * - 팀장     : 자기 + 자기 팀원 요청
+     * - 부장     : 전체
+     */
+    @Transactional(readOnly = true)
+    public PkgRequestDetailResponse getRequestDetail(Long requestId, Long viewerId) {
+
+        // 1) 요청 엔티티 가져오기
+        PkgRequest request = pkgRequestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException("PkgRequest not found: " + requestId));
+
+        Long ownerId = request.getRequestedBy().getId();
+
+        // 2) 이 사람이 이 요청을 볼 수 있는지 권한 체크
+        if (!canViewRequestDetail(viewerId, request)) {
+            throw new RuntimeException("이 요청을 조회할 권한이 없습니다.");
+        }
+
+        // 3) 승인/반려 이력 조회
+        var approvals = pkgApprovalRepository
+                .findByPkgRequest_IdOrderByDecidedAtAsc(requestId)
+                .stream()
+                .map(PkgApprovalHistoryResponse::from)
+                .toList();
+
+        // 4) DTO 조합
+        return PkgRequestDetailResponse.of(request, approvals);
+    }
+
+    /**
+     * 내부 권한 체크 로직
+     */
+    private boolean canViewRequestDetail(Long viewerId, PkgRequest request) {
+
+        Long ownerId = request.getRequestedBy().getId();
+
+        // 1) 내가 올린 요청이면 무조건 OK
+        if (viewerId.equals(ownerId)) {
+            return true;
+        }
+
+        // 2) 부장(최종 승인 권한 있는 사람)은 전체 조회 가능
+        if (permissionChecker.canApproveFinal(viewerId)) {
+            return true;
+        }
+
+        // 3) 팀장(L1 승인 권한 있는 사람)은 "자기 팀 소속 유저의 요청"은 볼 수 있음
+        if (permissionChecker.canApproveL1(viewerId)) {
+            // 나(팀장)의 팀들
+            var myRoles = userRoleRepository.findByUserId(viewerId);
+            var myTeamIds = myRoles.stream()
+                    .map(ur -> ur.getTeam().getId())
+                    .distinct()
+                    .toList();
+
+            // 요청 올린 사람의 팀들
+            var ownerRoles = userRoleRepository.findByUserId(ownerId);
+            var ownerTeamIds = ownerRoles.stream()
+                    .map(ur -> ur.getTeam().getId())
+                    .distinct()
+                    .toList();
+
+            // 교집합이 있으면 같은 팀이라고 판단
+            boolean sameTeam = ownerTeamIds.stream().anyMatch(myTeamIds::contains);
+            if (sameTeam) {
+                return true;
+            }
+        }
+
+        // 4) 그 외(다른 팀 일반 유저)는 볼 수 없음
+        return false;
+    }
+
+
+
+
+
+    // 2) 내가 결재한 이력 (팀장: L1, 부장: FINAL)
+    @Transactional(readOnly = true)
+    public List<PkgRequestResponse> getMyApprovalHistory(Long userId) {
+
+        // 팀장/부장 여부는 PermissionChecker로 판단
+        boolean isFinal = permissionChecker.canApproveFinal(userId);
+        PkgApprovalStep step = isFinal ? PkgApprovalStep.FINAL : PkgApprovalStep.L1;
+
+        List<PkgApproval> approvals =
+                pkgApprovalRepository.findByApprover_IdAndStep(userId, step);
+
+        return approvals.stream()
+                .map(a -> PkgRequestResponse.from(a.getPkgRequest()))
+                .toList();
+    }
+
+    /**
+     * 3) 지금 내가 결재해야 하는 것들 (To-do)
+     *
+     *  - 부장(HEAD):
+     *      상태가 l1_approved 인 요청 전체
+     *
+     *  - 팀장(L1):
+     *      내 팀(team_id)에 속한 유저들이 올린 pending 요청들
+     *
+     *  - 사원:
+     *      결재할 To-do 없음 → 빈 리스트
+     */
+
+    @Transactional(readOnly = true)
+    public List<PkgRequestResponse> getMyTodoApprovals(Long userId) {
+
+        // ✅ 부장
+        if (permissionChecker.canApproveFinal(userId)) {
+            List<PkgRequest> list =
+                    pkgRequestRepository.findByStatusOrderByRequestedAtDesc(PkgRequestStatus.l1_approved);
+
+            return list.stream()
+                    .map(PkgRequestResponse::from)
+                    .toList();
+        }
+
+        // ✅ 팀장
+        if (permissionChecker.canApproveL1(userId)) {
+
+            List<UserRole> roles = userRoleRepository.findByUserId(userId);
+            if (roles.isEmpty()) {
+                throw new EntityNotFoundException("UserRole not found for userId=" + userId);
+            }
+
+            Long teamId = roles.get(0).getTeam().getId();
+
+            List<PkgRequest> list =
+                    pkgRequestRepository.findTeamPendingRequests(teamId, PkgRequestStatus.pending);
+
+            return list.stream()
+                    .map(PkgRequestResponse::from)
+                    .toList();
+        }
+
+        // ✅ 사원
+        return List.of();
+    }
+
+
+
+    // === 공통 조회 메서드 ===
     private PkgRequest getRequestOrThrow(Long id) {
         return pkgRequestRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("PkgRequest not found: " + id));

--- a/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
@@ -142,57 +142,80 @@ public class PackageService {
         }
 
         // 둘 다 아니면 권한 없음
-        throw new IllegalStateException("User has no approval permission: " + approverId);
+        throw new IllegalStateException("권한이 존재하지 않는 user: " + approverId);
     }
     @Transactional
     public PkgRequestResponse handleL1Approval(Long requestId, Long approverId, PkgApprovalActionRequest body) {
 
         if (!permissionChecker.canApproveL1(approverId)) {
-            throw new IllegalStateException("L1 approval not allowed for user=" + approverId);
+            throw new IllegalStateException("L1 승인 권한이 존재하지 않습니다. userId=" + approverId);
         }
 
+        // 우선 요청 엔티티는 읽어서, 승인 이력 작성용으로 사용
         PkgRequest request = getRequestOrThrow(requestId);
-
-        if (request.getStatus() != PkgRequestStatus.pending) {
-            throw new IllegalStateException("Only pending requests can be L1-approved or rejected");
-        }
 
         User approver = userRepository.findById(approverId)
                 .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
 
         String action = body.getAction();
-        String reason = body.getReason(); // nullable 일 수 있음
+        String reason = body.getReason(); // nullable 가능
+
+        Instant now = Instant.now();
 
         if ("approve".equalsIgnoreCase(action)) {
-            // 🔹 L1 승인
+            // 🔹 DB 조건부 UPDATE: pending → l1_approved 인 경우에만 1 row 업데이트
+            int updated = pkgRequestRepository.updateStatusIfMatches(
+                    requestId,
+                    PkgRequestStatus.pending,       // 기대 상태
+                    PkgRequestStatus.l1_approved,   // 바꿀 상태
+                    now
+            );
+
+            if (updated == 0) {
+                // 누가 먼저 처리했거나, 이미 상태가 바뀐 케이스
+                throw new IllegalStateException("이미 다른 승인자가 먼저 처리한 요청입니다. (L1)");
+            }
+
+            // 승인 이력 저장
             PkgApproval approval = PkgApproval.builder()
-                    .pkgRequest(request)                 // ✅ 빌더 메서드로 설정 (필드 직접 접근 X)
+                    .pkgRequest(request)
                     .step(PkgApprovalStep.L1)
                     .approver(approver)
                     .result(PkgApprovalResult.approved)
-                    .description(reason)                 // 승인/거절 사유
-                    .decidedAt(Instant.now())
+                    .description(reason)
+                    .decidedAt(now)
                     .build();
             pkgApprovalRepository.save(approval);
 
+            // 메모리 상 엔티티도 DB 상태와 맞춰 줌
             request.setStatus(PkgRequestStatus.l1_approved);
-            pkgRequestRepository.save(request);
+            request.setDecidedAt(now);
 
         } else if ("reject".equalsIgnoreCase(action)) {
-            // 🔹 L1 거절
+
+            int updated = pkgRequestRepository.updateStatusIfMatches(
+                    requestId,
+                    PkgRequestStatus.pending,       // pending인 경우에만 거절 가능
+                    PkgRequestStatus.rejected,
+                    now
+            );
+
+            if (updated == 0) {
+                throw new IllegalStateException("이미 다른 승인자가 먼저 처리한 요청입니다. (L1 거절)");
+            }
+
             PkgApproval approval = PkgApproval.builder()
                     .pkgRequest(request)
                     .step(PkgApprovalStep.L1)
                     .approver(approver)
                     .result(PkgApprovalResult.rejected)
                     .description(reason)
-                    .decidedAt(Instant.now())
+                    .decidedAt(now)
                     .build();
             pkgApprovalRepository.save(approval);
 
             request.setStatus(PkgRequestStatus.rejected);
-            request.setDecidedAt(Instant.now());
-            pkgRequestRepository.save(request);
+            request.setDecidedAt(now);
 
         } else {
             throw new IllegalArgumentException("Invalid action for L1: " + action);
@@ -200,6 +223,7 @@ public class PackageService {
 
         return PkgRequestResponse.from(request);
     }
+
 
     /**
      * 3) FINAL(부장) 승인/거절 공통 처리
@@ -211,42 +235,68 @@ public class PackageService {
             throw new IllegalStateException("Final approval not allowed for user=" + approverId);
         }
 
+        // 이 시점의 상태를 보고 유효한 상태인지 먼저 체크
         PkgRequest request = getRequestOrThrow(requestId);
 
         if (request.getStatus() != PkgRequestStatus.l1_approved
                 && request.getStatus() != PkgRequestStatus.pending) {
-            throw new IllegalStateException("Only pending or l1_approved can be finally approved/rejected");
+            throw new IllegalStateException("FINAL 승인/반려는 pending 또는 l1_approved 상태에서만 가능합니다.");
         }
 
         User approver = userRepository.findById(approverId)
-                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
+                .orElseThrow(() -> new EntityNotFoundException("승인자를 찾을 수 없습니다: " + approverId));
 
         String action = body.getAction();
         String reason = body.getReason();
+        Instant now = Instant.now();
+
+        // 현재 읽은 상태를 expectedStatus로 사용
+        PkgRequestStatus currentStatus = request.getStatus();
 
         if ("approve".equalsIgnoreCase(action)) {
-            // 🔹 FINAL 승인
+
+            int updated = pkgRequestRepository.updateStatusIfMatches(
+                    requestId,
+                    currentStatus,              // 지금 읽은 상태와 동일할 때만 승인
+                    PkgRequestStatus.approved,  // 최종 승인
+                    now
+            );
+
+            if (updated == 0) {
+                throw new IllegalStateException("이미 다른 승인자가 먼저 처리한 요청입니다. (FINAL 승인)");
+            }
+
             PkgApproval approval = PkgApproval.builder()
                     .pkgRequest(request)
                     .step(PkgApprovalStep.FINAL)
                     .approver(approver)
                     .result(PkgApprovalResult.approved)
                     .description(reason)
-                    .decidedAt(Instant.now())
+                    .decidedAt(now)
                     .build();
             pkgApprovalRepository.save(approval);
 
             request.setStatus(PkgRequestStatus.approved);
-            request.setDecidedAt(Instant.now());
-            pkgRequestRepository.save(request);
+            request.setDecidedAt(now);
 
-            // TODO: 여기서 ans_run 만들어서 실제 Ansible 설치 작업 트리거
-            // ex) ansibleService.triggerInstall(request);
+            // TODO: 여기서 ans_run 트리거 등 실제 설치 작업 호출 가능
+            // ansibleService.triggerInstall(request);
 
         } else if ("reject".equalsIgnoreCase(action)) {
-            // 🔹 FINAL 거절
+
             if (request.getStatus() == PkgRequestStatus.rejected) {
-                throw new IllegalStateException("Already rejected");
+                throw new IllegalStateException("이미 거절된 요청입니다.");
+            }
+
+            int updated = pkgRequestRepository.updateStatusIfMatches(
+                    requestId,
+                    currentStatus,              // 현재 상태에서만 거절 처리
+                    PkgRequestStatus.rejected,
+                    now
+            );
+
+            if (updated == 0) {
+                throw new IllegalStateException("이미 다른 승인자가 먼저 처리한 요청입니다. (FINAL 거절)");
             }
 
             PkgApproval approval = PkgApproval.builder()
@@ -255,13 +305,12 @@ public class PackageService {
                     .approver(approver)
                     .result(PkgApprovalResult.rejected)
                     .description(reason)
-                    .decidedAt(Instant.now())
+                    .decidedAt(now)
                     .build();
             pkgApprovalRepository.save(approval);
 
             request.setStatus(PkgRequestStatus.rejected);
-            request.setDecidedAt(Instant.now());
-            pkgRequestRepository.save(request);
+            request.setDecidedAt(now);
 
         } else {
             throw new IllegalArgumentException("Invalid action for FINAL: " + action);
@@ -269,6 +318,7 @@ public class PackageService {
 
         return PkgRequestResponse.from(request);
     }
+
     @Transactional(readOnly = true)
     public List<PkgRequestResponse> getPendingRequestsByTeam(Long teamId) {
         // 팀 단위의 pending 요청들 조회 (팀장 화면 등에서 사용)

--- a/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
@@ -125,6 +125,17 @@ public class PackageService {
      *  - reason: 승인/거절 사유 (pkg_approval.description에 저장)
      */
     @Transactional
+    public PkgRequestResponse approveOrReject(Long requestId, Long approverId, PkgApprovalActionRequest body) {
+        String step = body.getStep(); // "L1" or "FINAL"
+        if ("L1".equalsIgnoreCase(step)) {
+            return handleL1Approval(requestId, approverId, body);
+        } else if ("FINAL".equalsIgnoreCase(step)) {
+            return handleFinalApproval(requestId, approverId, body);
+        } else {
+            throw new IllegalArgumentException("Invalid step: " + step);
+        }
+    }
+    @Transactional
     public PkgRequestResponse handleL1Approval(Long requestId, Long approverId, PkgApprovalActionRequest body) {
 
         if (!permissionChecker.canApproveL1(approverId)) {

--- a/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/pkg/PackageService.java
@@ -1,4 +1,194 @@
 package com.cloudrangers.cloudpilot.service.pkg;
 
+import com.cloudrangers.cloudpilot.domain.pkg.PkgApproval;
+import com.cloudrangers.cloudpilot.domain.pkg.PkgRequest;
+import com.cloudrangers.cloudpilot.domain.user.User;
+import com.cloudrangers.cloudpilot.dto.request.PkgRequestCreateRequest;
+import com.cloudrangers.cloudpilot.dto.response.PkgRequestResponse;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalResult;
+import com.cloudrangers.cloudpilot.enums.PkgApprovalStep;
+import com.cloudrangers.cloudpilot.enums.PkgRequestStatus;
+import com.cloudrangers.cloudpilot.repository.pkg.PkgApprovalRepository;
+import com.cloudrangers.cloudpilot.repository.pkg.PkgRequestRepository;
+import com.cloudrangers.cloudpilot.repository.user.UserRepository;
+import com.cloudrangers.cloudpilot.security.PermissionChecker;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class PackageService {
+
+    private final PkgRequestRepository pkgRequestRepository;
+    private final PkgApprovalRepository pkgApprovalRepository;
+    private final UserRepository userRepository;
+    private final PermissionChecker permissionChecker;
+
+    // 1) 패키지 설치 요청 생성
+    @Transactional
+    public PkgRequestResponse createRequest(PkgRequestCreateRequest reqDto, Long requesterId) {
+
+        // 1. 요청한 사용자 찾기
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found: " + requesterId));
+
+        // 2. 이 사람이 "팀장 권한(L1 승인 가능)"인지 확인
+        //    - 팀장이면: 요청 넣자마자 L1 승인된 상태로 저장
+        //    - 팀장이 아니면: 그냥 pending 상태로 저장
+        PkgRequestStatus initialStatus;
+        if (permissionChecker.canApproveL1(requesterId)) {
+            initialStatus = PkgRequestStatus.l1_approved;
+        } else {
+            initialStatus = PkgRequestStatus.pending;
+        }
+
+        // 3. 요청 엔티티 생성
+        PkgRequest request = PkgRequest.builder()
+                .requestedBy(requester)
+                .packageName(reqDto.getPackageName())
+                .packageVer(reqDto.getPackageVer())
+                .description(reqDto.getDescription())
+                .status(initialStatus)
+                .build();
+
+        // 4. 저장
+        PkgRequest saved = pkgRequestRepository.save(request);
+        log.info("Created pkg_request id={} by user={}, initialStatus={}",
+                saved.getId(), requesterId, initialStatus);
+
+        return PkgRequestResponse.from(saved);
+    }
+
+    // === 아래 L1/FINAL 승인/거절 메서드는 그대로 두면 됨 ===
+
+    @Transactional
+    public PkgRequestResponse approveL1(Long requestId, Long approverId) {
+        if (!permissionChecker.canApproveL1(approverId)) {
+            throw new IllegalStateException("L1 approval not allowed for user=" + approverId);
+        }
+
+        PkgRequest request = getRequestOrThrow(requestId);
+
+        if (request.getStatus() != PkgRequestStatus.pending) {
+            throw new IllegalStateException("Only pending requests can be L1-approved");
+        }
+
+        User approver = userRepository.findById(approverId)
+                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
+
+        PkgApproval approval = PkgApproval.builder()
+                .pkgRequest(request)
+                .step(PkgApprovalStep.L1)
+                .approver(approver)
+                .result(PkgApprovalResult.approved)
+                .build();
+        pkgApprovalRepository.save(approval);
+
+        request.setStatus(PkgRequestStatus.l1_approved);
+        pkgRequestRepository.save(request);
+
+        return PkgRequestResponse.from(request);
+    }
+
+    @Transactional
+    public PkgRequestResponse rejectL1(Long requestId, Long approverId) {
+        if (!permissionChecker.canApproveL1(approverId)) {
+            throw new IllegalStateException("L1 approval not allowed for user=" + approverId);
+        }
+
+        PkgRequest request = getRequestOrThrow(requestId);
+
+        if (request.getStatus() != PkgRequestStatus.pending) {
+            throw new IllegalStateException("Only pending requests can be rejected at L1");
+        }
+
+        User approver = userRepository.findById(approverId)
+                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
+
+        PkgApproval approval = PkgApproval.builder()
+                .pkgRequest(request)
+                .step(PkgApprovalStep.L1)
+                .approver(approver)
+                .result(PkgApprovalResult.rejected)
+                .build();
+        pkgApprovalRepository.save(approval);
+
+        request.setStatus(PkgRequestStatus.rejected);
+        request.setDecidedAt(Instant.now());
+        pkgRequestRepository.save(request);
+
+        return PkgRequestResponse.from(request);
+    }
+
+    @Transactional
+    public PkgRequestResponse approveFinal(Long requestId, Long approverId) {
+        if (!permissionChecker.canApproveFinal(approverId)) {
+            throw new IllegalStateException("Final approval not allowed for user=" + approverId);
+        }
+
+        PkgRequest request = getRequestOrThrow(requestId);
+
+        if (request.getStatus() != PkgRequestStatus.l1_approved &&
+                request.getStatus() != PkgRequestStatus.pending) {
+            throw new IllegalStateException("Only pending or l1_approved requests can be finally approved");
+        }
+
+        User approver = userRepository.findById(approverId)
+                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
+
+        PkgApproval approval = PkgApproval.builder()
+                .pkgRequest(request)
+                .step(PkgApprovalStep.FINAL)
+                .approver(approver)
+                .result(PkgApprovalResult.approved)
+                .build();
+        pkgApprovalRepository.save(approval);
+
+        request.setStatus(PkgRequestStatus.approved);
+        request.setDecidedAt(Instant.now());
+        pkgRequestRepository.save(request);
+
+        return PkgRequestResponse.from(request);
+    }
+
+    @Transactional
+    public PkgRequestResponse rejectFinal(Long requestId, Long approverId) {
+        if (!permissionChecker.canApproveFinal(approverId)) {
+            throw new IllegalStateException("Final approval not allowed for user=" + approverId);
+        }
+
+        PkgRequest request = getRequestOrThrow(requestId);
+
+        if (request.getStatus() == PkgRequestStatus.rejected) {
+            throw new IllegalStateException("Already rejected");
+        }
+
+        User approver = userRepository.findById(approverId)
+                .orElseThrow(() -> new EntityNotFoundException("Approver not found: " + approverId));
+
+        PkgApproval approval = PkgApproval.builder()
+                .pkgRequest(request)
+                .step(PkgApprovalStep.FINAL)
+                .approver(approver)
+                .result(PkgApprovalResult.rejected)
+                .build();
+        pkgApprovalRepository.save(approval);
+
+        request.setStatus(PkgRequestStatus.rejected);
+        request.setDecidedAt(Instant.now());
+        pkgRequestRepository.save(request);
+
+        return PkgRequestResponse.from(request);
+    }
+
+    private PkgRequest getRequestOrThrow(Long id) {
+        return pkgRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("PkgRequest not found: " + id));
+    }
 }


### PR DESCRIPTION
📌 Summary

패키지 설치 요청 생성 기능 구현

* 사원이 패키지 설치 요청을 생성할 수 있도록 API 구현
* 요청 시 `packageName`, `packageVer`, `description` 입력
* 요청 데이터가 `pkg_request` 테이블에 자동 저장

---

패키지 요청 상태 조회 기능 통합

단일 엔드포인트(`/packages/requests`)로 다음 상태를 구분하여 조회 가능하도록 통합:

* **view=my** → 내가 올린 요청 목록 조회
* **view=history** → 내가 승인/반려한 요청 이력 조회
* **view=todo** → 지금 내가 결재해야 하는 요청 목록 조회

  * 팀장: 팀원의 pending 요청
  * 부장: 전체 l1_approved 요청

---

단일 요청 상세조회(승인/반려 이력 포함) 구현

* `/packages/requests/{id}` 호출 시

  * 패키지 요청 정보
  * 승인/반려 히스토리 전체
    를 한 번에 반환하도록 설계
* 권한(Role) 기반 접근 제어 적용

  * 사원: 본인 요청만
  * 팀장: 자신의 팀원 + 본인 요청
  * 부장: 전체 요청 접근 가능

---

승인/반려 처리 API 단일화

* team leader(팀장) 또는 head(부장) 여부는 PermissionChecker로 판단
* 승인/반려와 동시에 `pkg_approval` 히스토리 자동 저장

  * 승인/반려자
  * 승인 단계(L1 or FINAL)
  * 결과(approved/rejected)
  * 사유(description 포함)

---

승인·반려 사유(description) 저장 기능 추가

* 요청 생성 시 description
* 승인/반려 시 description 기록
* 상세조회 시 모든 승인/반려 사유 확인 가능

---

✍️ Description

- close:

💡 PR Point

- 

📚 Reference

🔥 Test
- 사원 요청
<img width="840" height="881" alt="image" src="https://github.com/user-attachments/assets/4d60765d-d27f-4363-a64f-93ee315786a4" />

- 사원 요청 확인
<img width="823" height="878" alt="image" src="https://github.com/user-attachments/assets/bcadb628-a372-4545-bacb-c96d43ee7897" />

- 사원 요청 상세 조회(사유)
<img width="958" height="1012" alt="image" src="https://github.com/user-attachments/assets/259f68f2-b635-40f5-ba97-58f309d66702" />

- 팀장 승인
<img width="957" height="1015" alt="image" src="https://github.com/user-attachments/assets/e392084a-eb8d-4c91-a09f-8d05d04b6bd1" />

- 팀장 요청 확인(todo list)
<img width="955" height="960" alt="image" src="https://github.com/user-attachments/assets/21a45261-a618-46d2-a984-bcb74d941472" />

- 팀의 요청(승인한 것 + 자신)
<img width="956" height="1017" alt="image" src="https://github.com/user-attachments/assets/73d0eb59-803b-4b5d-aa9c-c76b89aa3c1a" />







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 패키지 요청 관리: 요청 생성, 상세 조회, 목록 보기 기능 추가.
  * 승인 워크플로우: L1/최종 단계 기반 승인·거부 및 승인 이력 기록 지원.
  * 개인 및 팀 관점 뷰: 내 요청, 승인 이력, 내 할 일(승인 대기) 조회 및 팀 기반 접근 제어 제공.
  * 안정성 개선: 요청 상태 업데이트와 결정 시점 기록이 포함된 처리 흐름 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->