### PR TITLE
[feat] #55 - VM 삭제 기능 구현

### DIFF
--- a/src/main/java/com/cloudrangers/cloudpilot/config/RabbitMQConfig.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/config/RabbitMQConfig.java
@@ -1,5 +1,6 @@
 package com.cloudrangers.cloudpilot.config;
 
+import com.cloudrangers.cloudpilot.dto.message.ProvisionResultMessage;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +11,7 @@ import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.DefaultClassMapper;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,6 +19,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.amqp.SimpleRabbitListenerContainerFactoryConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @EnableRabbit
 @Configuration
@@ -61,7 +66,23 @@ public class RabbitMQConfig {
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-        return new Jackson2JsonMessageConverter(objectMapper);
+        Jackson2JsonMessageConverter converter = new Jackson2JsonMessageConverter(objectMapper);
+
+        // ⭐ __TypeId__ 헤더를 worker DTO → API DTO로 매핑
+        DefaultClassMapper classMapper = new DefaultClassMapper();
+        classMapper.setTrustedPackages("*");
+
+        Map<String, Class<?>> idClassMapping = new HashMap<>();
+        // worker 가 보낸 __TypeId__ 를 API 쪽 DTO로 역직렬화
+        idClassMapping.put(
+                "com.cloudrangers.cloudpilotworker.dto.ProvisionResultMessage",
+                ProvisionResultMessage.class
+        );
+        classMapper.setIdClassMapping(idClassMapping);
+
+        converter.setClassMapper(classMapper);
+
+        return converter;
     }
 
     @Bean
@@ -187,7 +208,6 @@ public class RabbitMQConfig {
                 .to(exchange)
                 .with(packageRoutingKey);
     }
-
 
     // ================================================================
     //           패키지 설치 Result Queue / Exchange / Binding

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/VmController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/VmController.java
@@ -4,11 +4,16 @@ import com.cloudrangers.cloudpilot.common.ApiResponse;
 import com.cloudrangers.cloudpilot.dto.response.DeleteVmResponse;
 import com.cloudrangers.cloudpilot.dto.response.VmDetailResponse;
 import com.cloudrangers.cloudpilot.dto.response.VmStatusResponse;
+import com.cloudrangers.cloudpilot.security.AuthUtil;
 import com.cloudrangers.cloudpilot.service.vm.VmDeleteService;
 import com.cloudrangers.cloudpilot.service.vm.VmQueryService;
 import com.cloudrangers.cloudpilot.service.vm.VmReadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import com.cloudrangers.cloudpilot.dto.common.PageResponse;
 import java.time.Instant;
@@ -18,6 +23,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/vms")
 @RequiredArgsConstructor
+@Tag(name = "VM Management", description = "가상 머신 관리 API")
 public class VmController {
 
     private final VmQueryService vmQueryService;
@@ -28,6 +34,7 @@ public class VmController {
      * VM 리스트 조회 (필터/정렬/태그)
      */
     @GetMapping
+    @Operation(summary = "VM 목록 조회", description = "필터, 정렬, 태그 조건으로 VM 목록을 조회합니다")
     public ApiResponse<PageResponse<VmStatusResponse>> getVms(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
@@ -64,24 +71,91 @@ public class VmController {
      * VM 상세 조회
      */
     @GetMapping("/{vmId}")
-    public ApiResponse<VmDetailResponse> getVmDetail(@PathVariable Long vmId) {
+    @Operation(summary = "VM 상세 조회", description = "VM의 상세 정보를 조회합니다")
+    public ApiResponse<VmDetailResponse> getVmDetail(
+            @Parameter(description = "VM ID", required = true)
+            @PathVariable Long vmId
+    ) {
         return ApiResponse.success(vmQueryService.getVmDetail(vmId));
     }
 
     /**
-     * VM 삭제(비동기 큐잉) - 실제 삭제는 워커가 처리한다는 가정
+     * ⭐ VM 삭제 (비동기 처리)
+     * - JWT 토큰에서 사용자 정보 추출
+     * - lifecycle 상태를  'deleting'으로 변경
+     * - RabbitMQ를 통해 Worker에게 terraform destroy 요청
+     * - 실제 삭제는 Worker가 비동기로 처리
+     *
+     * @param vmId 삭제할 VM ID
+     * @return 삭제 Job 정보 (jobId, status 등)
      */
     @DeleteMapping("/{vmId}")
+    @ResponseStatus(HttpStatus.ACCEPTED)  // ⭐ 202 Accepted
+    @Operation(
+            summary = "VM 삭제",
+            description = "VM을 비동기로 삭제합니다. JWT 토큰으로 인증된 사용자만 요청할 수 있으며, 삭제 요청이 큐에 적재되고 Worker가 terraform destroy를 실행합니다."
+    )
     public ApiResponse<DeleteVmResponse> deleteVm(
-            @PathVariable Long vmId,
-            @RequestHeader(value = "X-USER-ID", required = false) Long requestedBy // 임시: 인증 연동 전
+            @Parameter(description = "삭제할 VM ID", required = true)
+            @PathVariable("vmId") Long vmId  // ⭐ "vmId" 명시
     ) {
-        return ApiResponse.success(vmDeleteService.enqueueDeletion(vmId, requestedBy));
+        // ⭐ JWT 토큰에서 현재 로그인한 사용자 ID 추출
+        Long requestedBy = AuthUtil.getUserId();
+
+        if (requestedBy == null) {
+            throw new IllegalStateException("인증되지 않은 사용자입니다. JWT 토큰을 확인해주세요.");
+        }
+
+        // VmDeleteService를 통해 삭제 Job 큐에 적재
+        DeleteVmResponse response = vmDeleteService.enqueueDeletion(vmId, requestedBy);
+
+        return ApiResponse.success(response);
     }
+
+    /**
+     * VM 삭제 요청 (기존 메서드 - 필요시 유지)
+     *
+     * @deprecated deleteVm() 메서드를 사용하세요
+     */
     @PostMapping("/{vmId}/delete-request")
-    public ApiResponse<Void> requestDelete(@PathVariable Long vmId) {
+    @Operation(
+            summary = "VM 삭제 요청 (레거시)",
+            description = "레거시 API입니다. DELETE /{vmId} 사용을 권장합니다."
+    )
+    @Deprecated
+    public ApiResponse<Void> requestDelete(
+            @Parameter(description = "VM ID", required = true)
+            @PathVariable Long vmId
+    ) {
         vmQueryService.requestDelete(vmId);
         return ApiResponse.success(null);
     }
 
+    /**
+     * ⭐ VM 삭제 상태 조회 (선택적 추가)
+     * - lifecycle 필드를 통해 삭제 진행 상태 확인
+     *
+     * @param vmId VM ID
+     * @return VM lifecycle 상태 (deleting, deleted, running 등)
+     */
+//    @GetMapping("/{vmId}/deletion-status")
+//    @Operation(
+//            summary = "VM 삭제 상태 조회",
+//            description = "VM의 현재 삭제 상태를 조회합니다 (lifecycle 필드)"
+//    )
+//    public ApiResponse<Map<String, String>> getDeletionStatus(
+//            @Parameter(description = "VM ID", required = true)
+//            @PathVariable Long vmId
+//    ) {
+//        // VmDetailResponse에서 lifecycle 추출
+//        VmDetailResponse detail = vmQueryService.getVmDetail(vmId);
+//
+//        Map<String, String> status = new HashMap<>();
+//        status.put("vmId", String.valueOf(vmId));
+//        status.put("vmName", detail.getName());
+//        status.put("lifecycle", detail.getLifecycle());
+//        status.put("powerState", detail.getPowerState());
+//
+//        return ApiResponse.success(status);
+//    }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/controller/VmController.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/controller/VmController.java
@@ -1,6 +1,7 @@
 package com.cloudrangers.cloudpilot.controller;
 
 import com.cloudrangers.cloudpilot.common.ApiResponse;
+import com.cloudrangers.cloudpilot.dto.common.PageResponse;
 import com.cloudrangers.cloudpilot.dto.response.DeleteVmResponse;
 import com.cloudrangers.cloudpilot.dto.response.VmDetailResponse;
 import com.cloudrangers.cloudpilot.dto.response.VmStatusResponse;
@@ -14,8 +15,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
-import com.cloudrangers.cloudpilot.dto.common.PageResponse;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,7 +82,7 @@ public class VmController {
     }
 
     /**
-     * ⭐ VM 삭제 (비동기 처리)
+     *  VM 삭제 (비동기 처리)
      * - JWT 토큰에서 사용자 정보 추출
      * - lifecycle 상태를  'deleting'으로 변경
      * - RabbitMQ를 통해 Worker에게 terraform destroy 요청
@@ -90,20 +92,19 @@ public class VmController {
      * @return 삭제 Job 정보 (jobId, status 등)
      */
     @DeleteMapping("/{vmId}")
-    @ResponseStatus(HttpStatus.ACCEPTED)  // ⭐ 202 Accepted
+    @ResponseStatus(HttpStatus.ACCEPTED)
     @Operation(
             summary = "VM 삭제",
             description = "VM을 비동기로 삭제합니다. JWT 토큰으로 인증된 사용자만 요청할 수 있으며, 삭제 요청이 큐에 적재되고 Worker가 terraform destroy를 실행합니다."
     )
     public ApiResponse<DeleteVmResponse> deleteVm(
             @Parameter(description = "삭제할 VM ID", required = true)
-            @PathVariable("vmId") Long vmId  // ⭐ "vmId" 명시
+            @PathVariable("vmId") Long vmId
     ) {
-        // ⭐ JWT 토큰에서 현재 로그인한 사용자 ID 추출
         Long requestedBy = AuthUtil.getUserId();
 
         if (requestedBy == null) {
-            throw new IllegalStateException("인증되지 않은 사용자입니다. JWT 토큰을 확인해주세요.");
+            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
         }
 
         // VmDeleteService를 통해 삭제 Job 큐에 적재
@@ -132,7 +133,7 @@ public class VmController {
     }
 
     /**
-     * ⭐ VM 삭제 상태 조회 (선택적 추가)
+     * ⭐ VM 삭제 상태 조회
      * - lifecycle 필드를 통해 삭제 진행 상태 확인
      *
      * @param vmId VM ID

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/pipeline/TfRun.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/pipeline/TfRun.java
@@ -25,8 +25,9 @@ public class TfRun {
     private Long id;
 
     // N:1 (Pipeline:TfRun)
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "pipeline_id", nullable = false)
+    // ✅ optional = true로 변경 (VM 프로비저닝에서는 Pipeline 없이 사용)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pipeline_id")
     private Pipeline pipeline;
 
     /** 실행에 사용되는 provider_account_id (DB 컬럼 그대로 매핑) */
@@ -34,11 +35,11 @@ public class TfRun {
     private Long providerAccountId;
 
     /** 사용한 Terraform Module Version ID */
-    @Column(name = "module_version_id", nullable = false)
+    @Column(name = "module_version_id")
     private Long moduleVersionId;
 
     /** 사용한 Varset ID */
-    @Column(name = "varset_id", nullable = false)
+    @Column(name = "varset_id")
     private Long varsetId;
 
     @Column(name = "workspace", length = 200)

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/provision/VmProvisionItem.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/provision/VmProvisionItem.java
@@ -12,7 +12,8 @@ import org.hibernate.type.SqlTypes;
 @Entity
 @Table(name = "vm_provision_item",
         indexes = {
-                @Index(name = "idx_provision_item_job", columnList = "provision_job_id")
+                @Index(name = "idx_provision_item_job", columnList = "provision_job_id"),
+                @Index(name = "idx_provision_item_tf_run", columnList = "tf_run_id")  // ✅ 추가
         })
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
@@ -27,6 +28,9 @@ public class VmProvisionItem {
     @JoinColumn(name = "provision_job_id", nullable = false,
             foreignKey = @ForeignKey(name = "fk_vm_provision_item_job"))
     private VmProvisionJob provisionJob;
+
+    @Column(name = "tf_run_id")
+    private Long tfRunId;
 
     // 외래키는 우선 ID로만
     @Column(name = "os_image_id", nullable = false)

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/vm/VmInstance.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/vm/VmInstance.java
@@ -21,6 +21,14 @@ public class VmInstance {
     @Column(name = "provision_item_id")
     private Long provisionItemId;
 
+    // 🔥 추가: 이 VM을 만든 Terraform 실행(tf_run)의 ID
+    @Column(name = "tf_run_id")
+    private Long tfRunId;
+
+    // 🔥 추가: 해당 실행에서 사용한 terraform state 파일 경로(워커 로컬 경로)
+    @Column(name = "state_uri", length = 1024)
+    private String stateUri;
+
     private String name;           // VM 이름
     private String providerType;   // AWS / VSPHERE
     private Long zoneId;           // Zone 참조
@@ -55,4 +63,3 @@ public class VmInstance {
     @Column(name = "ip")
     private String ip;
 }
-

--- a/src/main/java/com/cloudrangers/cloudpilot/domain/vm/VmInstance.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/domain/vm/VmInstance.java
@@ -18,6 +18,9 @@ public class VmInstance {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "provision_item_id")
+    private Long provisionItemId;
+
     private String name;           // VM 이름
     private String providerType;   // AWS / VSPHERE
     private Long zoneId;           // Zone 참조

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/message/ProvisionJobMessage.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/message/ProvisionJobMessage.java
@@ -16,8 +16,9 @@ public class ProvisionJobMessage {
 
     // ===== 공통/식별 =====
     private String jobId;
-    private Object providerType;     // "VSPHERE" 등 (Enum/문자열 허용)
-    private Integer zoneId;
+    private String action;          // "apply" | "destroy" 등
+    private Object providerType;    // "VSPHERE" 등 (Enum/문자열 허용)
+    private Long zoneId;            // 워커 DTO와 맞추기 위해 Long 사용
 
     // ===== 호출자 컨텍스트(워커 로그/추적용) =====
     private Long userId;
@@ -48,9 +49,6 @@ public class ProvisionJobMessage {
     // ===== API 원본 요청 스냅샷(재시도/감사용) =====
     private ProvisionRequest request;  // 워커 DTO에 없더라도 JSON 역직렬화 시 무시됨
 
-    // ===== 워크플로 액션 =====
-    private String action; // "apply" | "destroy" 등
-
     // ===== CL/OS/초기화(앞으로 확장용; 워커는 unknown 무시) =====
     private TemplateRef    template;      // CL 템플릿 메타
     private OsSpec         os;            // OS 선택
@@ -58,6 +56,7 @@ public class ProvisionJobMessage {
     private PropertiesSpec properties;    // cloud-init/Windows customize
 
     // ---------- Nested Types ----------
+
     @Data
     public static class TemplateRef {
         private String itemName;           // os_image.template_name
@@ -65,6 +64,7 @@ public class ProvisionJobMessage {
         private String templateDatastore;  // os_image.template_datastore
         private String guestId;            // os_image.guest_id
         private String contentLibraryName; // 선택
+        private String uuid;               // 템플릿 UUID (워커 DTO와 정합성용, 선택)
     }
 
     @Data
@@ -85,7 +85,7 @@ public class ProvisionJobMessage {
         @Data
         public static class Ipv4 {
             private String address;
-            private Integer prefix;
+            private Integer prefix;   // CIDR prefix (예: 24)
             private String gateway;
         }
     }

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/message/ProvisionJobMessage.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/message/ProvisionJobMessage.java
@@ -20,6 +20,10 @@ public class ProvisionJobMessage {
     private Object providerType;    // "VSPHERE" 등 (Enum/문자열 허용)
     private Long zoneId;            // 워커 DTO와 맞추기 위해 Long 사용
 
+    // ===== Terraform 상태 파일 경로(선택) =====
+    // BE에서 미리 계산해서 넘겨주면 워커가 그대로 사용 가능
+    private String stateUri;
+
     // ===== 호출자 컨텍스트(워커 로그/추적용) =====
     private Long userId;
     private Long teamId;

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/message/ProvisionResultMessage.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/message/ProvisionResultMessage.java
@@ -31,6 +31,10 @@ public class ProvisionResultMessage {
     // SUCCESS일 때만 채우는 VM 정보 (여러 개 가능)
     private List<InstanceInfo> instances;
 
+    // ✅ 추가: Terraform State 관리
+    private Long tfRunId;          // tf_run 테이블 PK
+    private String stateUri;       // Terraform state 파일 경로
+
     public ProvisionResultMessage() {}
 
     // 예전 코드 호환용 생성자
@@ -67,6 +71,14 @@ public class ProvisionResultMessage {
     public List<InstanceInfo> getInstances() { return instances; }
     public void setInstances(List<InstanceInfo> instances) { this.instances = instances; }
 
+    // ✅ 추가: tfRunId getter/setter
+    public Long getTfRunId() { return tfRunId; }
+    public void setTfRunId(Long tfRunId) { this.tfRunId = tfRunId; }
+
+    // ✅ 추가: stateUri getter/setter
+    public String getStateUri() { return stateUri; }
+    public void setStateUri(String stateUri) { this.stateUri = stateUri; }
+
     @Override
     public String toString() {
         return "ProvisionResultMessage{" +
@@ -78,6 +90,8 @@ public class ProvisionResultMessage {
                 ", step='" + step + '\'' +
                 ", timestamp=" + timestamp +
                 ", instances=" + instances +
+                ", tfRunId=" + tfRunId +  // ✅ 추가
+                ", stateUri='" + stateUri + '\'' +  // ✅ 추가
                 '}';
     }
 

--- a/src/main/java/com/cloudrangers/cloudpilot/dto/response/DeleteVmResponse.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/dto/response/DeleteVmResponse.java
@@ -1,4 +1,3 @@
-// src/main/java/com/cloudrangers/cloudpilot/dto/response/DeleteVmResponse.java
 package com.cloudrangers.cloudpilot.dto.response;
 
 import lombok.AllArgsConstructor;
@@ -6,13 +5,23 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 @Data
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class DeleteVmResponse {
-    private String jobId;      // String (UUID 등)
-    private Long vmId;
-    private String status;     // "QUEUED" 등
-    private Long requestedBy;  // 서비스에서 내려주는 필드가 있으니 DTO에도 추가
+
+    private String jobId;           // 삭제 Job ID (UUID)
+    private Long vmId;              // VM Instance ID
+    private String vmName;          // VM 이름
+    private String status;          // QUEUED / DELETING / DELETED / FAILED
+    private Long requestedBy;       // 요청자 User ID
+    private Instant requestedAt;    // 요청 시간
+    private String message;         // 상태 메시지
+
+    // 추가 정보 (선택)
+    private String providerType;    // VSPHERE / AWS
+    private Long zoneId;            // Zone ID
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pipeline/TfRunRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pipeline/TfRunRepository.java
@@ -1,0 +1,9 @@
+package com.cloudrangers.cloudpilot.repository.pipeline;
+
+import com.cloudrangers.cloudpilot.domain.pipeline.TfRun;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TfRunRepository extends JpaRepository<TfRun, Long> {
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/pipeline/TfRunRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/pipeline/TfRunRepository.java
@@ -2,8 +2,35 @@ package com.cloudrangers.cloudpilot.repository.pipeline;
 
 import com.cloudrangers.cloudpilot.domain.pipeline.TfRun;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TfRunRepository extends JpaRepository<TfRun, Long> {
+
+    /**
+     * 특정 provision_job_id에 대해
+     * action = 'apply' AND status = 'succeeded' 인 가장 마지막 TfRun 1건 조회
+     *
+     * ⚠️ enum / 문자열이 DB에서 대소문자 다르면 여기 문자열도 맞게 바꿔줘야 함
+     */
+    @Query(
+            value = """
+            SELECT *
+            FROM tf_run
+            WHERE provision_job_id = :provisionJobId
+              AND action = 'apply'
+              AND status = 'succeeded'
+            ORDER BY id DESC
+            LIMIT 1
+        """,
+            nativeQuery = true
+    )
+    Optional<TfRun> findLatestSucceededApply(@Param("provisionJobId") Long provisionJobId);
+
+    List<TfRun> findTop5ByOrderByIdDesc();
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/repository/provision/VmProvisionItemRepository.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/repository/provision/VmProvisionItemRepository.java
@@ -1,0 +1,15 @@
+package com.cloudrangers.cloudpilot.repository.provision;
+
+import com.cloudrangers.cloudpilot.domain.provision.VmProvisionItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface VmProvisionItemRepository extends JpaRepository<VmProvisionItem, Long> {
+
+    List<VmProvisionItem> findByProvisionJobId(Long provisionJobId);
+
+    List<VmProvisionItem> findByTfRunId(Long tfRunId);
+}

--- a/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobQueueService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobQueueService.java
@@ -1,13 +1,22 @@
 package com.cloudrangers.cloudpilot.service.provision;
 
+import com.cloudrangers.cloudpilot.domain.pipeline.TfRun;
+import com.cloudrangers.cloudpilot.domain.provision.VmProvisionItem;
+import com.cloudrangers.cloudpilot.domain.vm.VmInstance;
 import com.cloudrangers.cloudpilot.dto.message.ProvisionJobMessage;
+import com.cloudrangers.cloudpilot.enums.TfRunAction;
+import com.cloudrangers.cloudpilot.enums.TfRunStatus;
+import com.cloudrangers.cloudpilot.repository.pipeline.TfRunRepository;
+import com.cloudrangers.cloudpilot.repository.provision.VmProvisionItemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.*;
 
 @Service
@@ -16,7 +25,9 @@ import java.util.*;
 public class JobQueueService {
 
     private final RabbitTemplate rabbitTemplate;
-    private final JdbcTemplate jdbcTemplate; // Spring Boot JPA 사용 시 이미 들어옴
+    private final JdbcTemplate jdbcTemplate;
+    private final TfRunRepository tfRunRepository;  // ✅ 추가
+    private final VmProvisionItemRepository vmProvisionItemRepository;  // ✅ 추가
 
     @Value("${rabbitmq.exchange.provision.name:provision-exchange}")
     private String exchangeName;
@@ -24,6 +35,10 @@ public class JobQueueService {
     @Value("${rabbitmq.routing-key.provision.base:provision.create}")
     private String baseRoutingKey;
 
+    // ========================================
+    // ⭐ 수정: VM 생성 - TfRun 생성 추가
+    // ========================================
+    @Transactional
     public void pushJob(ProvisionJobMessage msg, boolean highPriority) {
         // 0) 기본값 보정
         normalize(msg);
@@ -31,16 +46,40 @@ public class JobQueueService {
         // 1) 템플릿 Resolve (os_image)
         resolveTemplateFromOsImage(msg);
 
-        // 2) 라우팅키
-        final String routingKey = buildRoutingKey(msg);
+        // ✅ 2) TfRun 레코드 생성
+        TfRun tfRun = createTfRun(msg);
+
+        // ✅ 3) provisionItemId가 있으면 연결
+        if (msg.getAdditionalConfig() != null) {
+            Object itemIdObj = msg.getAdditionalConfig().get("provisionItemId");
+            if (itemIdObj != null) {
+                Long provisionItemId = Long.parseLong(String.valueOf(itemIdObj));
+
+                VmProvisionItem item = vmProvisionItemRepository.findById(provisionItemId)
+                        .orElse(null);
+
+                if (item != null) {
+                    item.setTfRunId(tfRun.getId());
+                    vmProvisionItemRepository.save(item);
+                    log.info("✓ VmProvisionItem linked to TfRun: itemId={}, tfRunId={}",
+                            provisionItemId, tfRun.getId());
+                }
+            }
+
+            // tfRunId를 메시지에 추가
+            msg.getAdditionalConfig().put("tfRunId", tfRun.getId());
+        }
+
+        // 4) 라우팅키
+        final String routingKey = buildRoutingKey(msg, "create");
 
         try {
             if (msg.getJobId() == null || msg.getJobId().isBlank()) {
                 msg.setJobId(UUID.randomUUID().toString());
             }
 
-            log.info("Publishing job: jobId={}, exchange={}, rk={}, provider={}, zone={}, template(item={}, moid={})",
-                    msg.getJobId(), exchangeName, routingKey,
+            log.info("Publishing job: jobId={}, tfRunId={}, exchange={}, rk={}, provider={}, zone={}, template(item={}, moid={})",
+                    msg.getJobId(), tfRun.getId(), exchangeName, routingKey,
                     msg.getProviderType(), msg.getZoneId(),
                     msg.getTemplate() != null ? msg.getTemplate().getItemName() : null,
                     msg.getTemplate() != null ? msg.getTemplate().getTemplateMoid() : null
@@ -53,6 +92,7 @@ public class JobQueueService {
                     m -> {
                         m.getMessageProperties().setCorrelationId(msg.getJobId());
                         m.getMessageProperties().setHeader("jobId", msg.getJobId());
+                        m.getMessageProperties().setHeader("tfRunId", tfRun.getId());  // ✅ 추가
                         m.getMessageProperties().setContentType("application/json");
                         return m;
                     }
@@ -60,16 +100,233 @@ public class JobQueueService {
 
         } catch (Exception e) {
             log.error("Rabbit publish failed: {}", e.getMessage(), e);
+
+            // TfRun 실패 처리
+            tfRun.setStatus(TfRunStatus.failed);
+            tfRun.setFinishedAt(Instant.now());
+            tfRunRepository.save(tfRun);
+
             throw e;
         }
     }
 
-    private String buildRoutingKey(ProvisionJobMessage msg) {
-        String providerLower = String.valueOf(msg.getProviderType()).toLowerCase(Locale.ROOT);
-        return baseRoutingKey + "." + providerLower; // e.g., provision.create.vsphere
+    // ========================================
+    // ⭐ 수정: VM 삭제 - state_uri 조회 및 전달
+    // ========================================
+    /**
+     * VM 삭제 Job을 RabbitMQ에 전송
+     *
+     * @param jobId Job ID (UUID)
+     * @param vm 삭제할 VM 인스턴스
+     * @param requestedBy 요청자 User ID
+     */
+    @Transactional
+    public void pushDeleteJob(String jobId, VmInstance vm, Long requestedBy) {
+        try {
+            // ✅ 1. vm_instance → vm_provision_item → tf_run 조회
+            TfRun originalTfRun = findOriginalTfRun(vm);
+
+            if (originalTfRun == null) {
+                log.warn("⚠️ No TfRun found for VM deletion: vmId={}, vmName={}",
+                        vm.getId(), vm.getName());
+            }
+
+            // ✅ 2. 새 TfRun 레코드 생성 (destroy용)
+            TfRun destroyTfRun = TfRun.builder()
+                    .workspace(vm.getName())
+                    .action(TfRunAction.destroy)
+                    .status(TfRunStatus.running)
+                    .stateBackend("local")
+                    .startedAt(Instant.now())
+                    .updatedAt(Instant.now())
+                    .build();
+
+            destroyTfRun = tfRunRepository.save(destroyTfRun);
+
+            // ✅ 람다에서 사용할 final 변수
+            final Long finalTfRunId = destroyTfRun.getId();
+
+            log.info("✓ TfRun created for destroy: id={}, workspace={}",
+                    finalTfRunId, destroyTfRun.getWorkspace());
+
+            // ✅ 3. ProvisionJobMessage 생성 (stateUri 포함)
+            ProvisionJobMessage msg = buildDestroyMessage(
+                    jobId,
+                    vm,
+                    requestedBy,
+                    finalTfRunId,
+                    originalTfRun != null ? originalTfRun.getStateUri() : null
+            );
+
+            // 4. 라우팅 키 생성 (provision.destroy.vsphere)
+            String routingKey = buildRoutingKey(msg, "destroy");
+
+            log.info("📤 Publishing destroy job: jobId={}, tfRunId={}, vmId={}, vmName={}, stateUri={}, exchange={}, routingKey={}",
+                    jobId, finalTfRunId, vm.getId(), vm.getName(),
+                    originalTfRun != null ? originalTfRun.getStateUri() : "null",
+                    exchangeName, routingKey);
+
+            // 5. RabbitMQ로 전송
+            rabbitTemplate.convertAndSend(
+                    exchangeName,
+                    routingKey,
+                    msg,
+                    m -> {
+                        m.getMessageProperties().setCorrelationId(jobId);
+                        m.getMessageProperties().setHeader("jobId", jobId);
+                        m.getMessageProperties().setHeader("tfRunId", finalTfRunId);  // ✅ final 변수 사용
+                        m.getMessageProperties().setHeader("action", "destroy");
+                        m.getMessageProperties().setContentType("application/json");
+                        return m;
+                    }
+            );
+
+            log.info("✅ Destroy job published successfully: jobId={}, tfRunId={}",
+                    jobId, finalTfRunId);
+
+        } catch (Exception e) {
+            log.error("❌ Failed to publish destroy job: jobId={}, vmId={}",
+                    jobId, vm.getId(), e);
+            throw new RuntimeException("Failed to enqueue VM deletion job", e);
+        }
     }
 
-    // ---------- 내부 유틸 ----------
+    // ========================================
+    // ⭐ 새로 추가: TfRun 관련 헬퍼 메서드들
+    // ========================================
+
+    /**
+     * VM 생성 시 TfRun 레코드 생성
+     */
+    private TfRun createTfRun(ProvisionJobMessage msg) {
+        TfRun tfRun = TfRun.builder()
+                .workspace(msg.getVmName())
+                .action(TfRunAction.apply)
+                .status(TfRunStatus.running)
+                .stateBackend("local")
+                .startedAt(Instant.now())
+                .updatedAt(Instant.now())
+                .build();
+
+        tfRun = tfRunRepository.save(tfRun);
+
+        log.info("✓ TfRun created: id={}, workspace={}, action={}",
+                tfRun.getId(), tfRun.getWorkspace(), tfRun.getAction());
+
+        return tfRun;
+    }
+
+    /**
+     * VM 삭제 시 원본 TfRun 조회
+     * vm_instance → vm_provision_item → tf_run
+     */
+    private TfRun findOriginalTfRun(VmInstance vm) {
+        // 1. vm.provisionItemId로 VmProvisionItem 조회
+        Long provisionItemId = vm.getProvisionItemId();
+
+        if (provisionItemId == null) {
+            log.warn("⚠️ VM has no provisionItemId: vmId={}", vm.getId());
+            return null;
+        }
+
+        // 2. VmProvisionItem에서 tfRunId 조회
+        VmProvisionItem item = vmProvisionItemRepository.findById(provisionItemId)
+                .orElse(null);
+
+        if (item == null || item.getTfRunId() == null) {
+            log.warn("⚠️ VmProvisionItem has no tfRunId: itemId={}", provisionItemId);
+            return null;
+        }
+
+        // 3. TfRun 조회
+        TfRun tfRun = tfRunRepository.findById(item.getTfRunId())
+                .orElse(null);
+
+        if (tfRun == null) {
+            log.warn("⚠️ TfRun not found: tfRunId={}", item.getTfRunId());
+            return null;
+        }
+
+        log.info("✓ Found original TfRun: tfRunId={}, stateUri={}",
+                tfRun.getId(), tfRun.getStateUri());
+
+        return tfRun;
+    }
+
+    // ========================================
+    // Private 헬퍼 메서드들
+    // ========================================
+
+    /**
+     * ⭐ 수정: action에 따라 라우팅 키 생성
+     * - create: provision.create.vsphere
+     * - destroy: provision.destroy.vsphere
+     */
+    private String buildRoutingKey(ProvisionJobMessage msg, String action) {
+        String providerLower = String.valueOf(msg.getProviderType()).toLowerCase(Locale.ROOT);
+
+        // baseRoutingKey = "provision.create"
+        // → "provision" + "." + action + "." + provider
+        String baseWithoutAction = baseRoutingKey.replace(".create", "");
+        return baseWithoutAction + "." + action + "." + providerLower;
+    }
+
+    /**
+     * ⭐ 수정: Terraform destroy를 위한 ProvisionJobMessage 생성
+     */
+    private ProvisionJobMessage buildDestroyMessage(
+            String jobId,
+            VmInstance vm,
+            Long requestedBy,
+            Long tfRunId,  // ✅ 추가
+            String stateUri  // ✅ 추가
+    ) {
+        ProvisionJobMessage msg = new ProvisionJobMessage();
+
+        // 기본 정보
+        msg.setJobId(jobId);
+        msg.setAction("destroy");  // ⭐ 핵심: Terraform destroy 실행
+        msg.setProviderType(vm.getProviderType());
+        msg.setZoneId(vm.getZoneId().intValue());
+
+        // VM 정보
+        msg.setVmName(vm.getName());
+        msg.setVmCount(1);  // 삭제는 항상 단일 VM
+
+        // 리소스 스펙 (삭제 시에는 참고용)
+        msg.setCpuCores(vm.getVcpu());
+        msg.setMemoryGb(vm.getMemoryMb() != null ? vm.getMemoryMb() / 1024 : null);
+        msg.setDiskGb(vm.getRootDiskGb());
+
+        // 사용자 컨텍스트
+        msg.setUserId(requestedBy);
+        msg.setTeamId(vm.getTeamId());
+
+        // ✅ 추가 설정 (Terraform State URI 전달)
+        Map<String, Object> additionalConfig = new LinkedHashMap<>();
+        additionalConfig.put("vmId", vm.getId());
+        additionalConfig.put("operation", "destroy");
+        additionalConfig.put("requestedBy", requestedBy);
+        additionalConfig.put("tfRunId", tfRunId);  // ✅ 추가
+
+        if (stateUri != null && !stateUri.isBlank()) {
+            additionalConfig.put("stateUri", stateUri);  // ✅ 핵심!
+            log.info("✓ State URI added to destroy message: {}", stateUri);
+        } else {
+            log.warn("⚠️ No state URI available for destroy operation");
+        }
+
+        msg.setAdditionalConfig(additionalConfig);
+
+        log.debug("🔨 Built destroy message: jobId={}, vmName={}, action={}, tfRunId={}",
+                jobId, vm.getName(), msg.getAction(), tfRunId);
+
+        return msg;
+    }
+
+    // ========================================
+    // 기존 메서드들 (변경 없음)
+    // ========================================
 
     private void normalize(ProvisionJobMessage msg) {
         if (msg.getJobId() == null || msg.getJobId().isBlank()) {
@@ -109,22 +366,12 @@ public class JobQueueService {
 
     private boolean blank(String s) { return s == null || s.isBlank(); }
 
-    /**
-     * os_image에서 템플릿을 찾아 msg.template 채움.
-     * - 1순위: code = "family-version-variant-arch"
-     * - 2순위: family/version 토큰 LIKE
-     *
-     * 주의: DB zone_id는 SMALLINT → 쿼리 파라미터는 int로 전달
-     * 메시지의 zoneId가 Long이든 Integer든 intValue()로 안전 변환
-     */
     private void resolveTemplateFromOsImage(ProvisionJobMessage msg) {
         if (msg.getTemplate() != null
                 && (!blank(msg.getTemplate().getItemName()) || !blank(msg.getTemplate().getTemplateMoid()))) {
-            // 이미 채워져 있으면 그대로 사용
             return;
         }
 
-        // ★ zoneId를 int로 통일
         Integer zoneIdInt = requireZoneIdInt(msg);
 
         String family  = safeLower(msg.getOs().getFamily());
@@ -134,7 +381,6 @@ public class JobQueueService {
 
         String code = (family + "-" + version + "-" + variant + "-" + arch);
 
-        // 1) code 정확 매칭
         List<Map<String, Object>> exact = jdbcTemplate.queryForList("""
             SELECT id, code, name, template_name, template_moid, template_datastore, os_family, os_version, guest_id
               FROM os_image
@@ -144,7 +390,6 @@ public class JobQueueService {
 
         Map<String, Object> row = !exact.isEmpty() ? exact.get(0) : null;
 
-        // 2) family/version 토큰 검색
         if (row == null) {
             String famLike = "%" + family + "%";
             String verLike = "%" + version + "%";
@@ -171,7 +416,6 @@ public class JobQueueService {
         t.setGuestId(          (String) row.get("guest_id"));
         msg.setTemplate(t);
 
-        // 참고: 추적 용도로 additionalConfig에 기록(선택)
         if (msg.getAdditionalConfig() == null) {
             msg.setAdditionalConfig(new LinkedHashMap<>());
         }
@@ -180,12 +424,10 @@ public class JobQueueService {
     }
 
     private Integer requireZoneIdInt(ProvisionJobMessage msg) {
-        // ProvisionJobMessage의 zoneId가 Long로 선언되어 있어도 int로 안전 변환
-        Object z = msg.getZoneId(); // Long/Integer 모두 처리
+        Object z = msg.getZoneId();
         if (z == null) throw new IllegalArgumentException("zoneId is required");
         if (z instanceof Integer i) return i;
         if (z instanceof Long l)    return Math.toIntExact(l);
-        // 혹시 문자열 등으로 올 경우 대비
         return Integer.parseInt(String.valueOf(z));
     }
 

--- a/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobQueueService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobQueueService.java
@@ -26,8 +26,8 @@ public class JobQueueService {
 
     private final RabbitTemplate rabbitTemplate;
     private final JdbcTemplate jdbcTemplate;
-    private final TfRunRepository tfRunRepository;  // ✅ 추가
-    private final VmProvisionItemRepository vmProvisionItemRepository;  // ✅ 추가
+    private final TfRunRepository tfRunRepository;
+    private final VmProvisionItemRepository vmProvisionItemRepository;
 
     @Value("${rabbitmq.exchange.provision.name:provision-exchange}")
     private String exchangeName;
@@ -36,7 +36,7 @@ public class JobQueueService {
     private String baseRoutingKey;
 
     // ========================================
-    // ⭐ 수정: VM 생성 - TfRun 생성 추가
+    // ⭐ VM 생성 - TfRun 생성 + 큐 발행
     // ========================================
     @Transactional
     public void pushJob(ProvisionJobMessage msg, boolean highPriority) {
@@ -46,29 +46,33 @@ public class JobQueueService {
         // 1) 템플릿 Resolve (os_image)
         resolveTemplateFromOsImage(msg);
 
-        // ✅ 2) TfRun 레코드 생성
+        // 2) TfRun 레코드 생성
         TfRun tfRun = createTfRun(msg);
 
-        // ✅ 3) provisionItemId가 있으면 연결
-        if (msg.getAdditionalConfig() != null) {
-            Object itemIdObj = msg.getAdditionalConfig().get("provisionItemId");
-            if (itemIdObj != null) {
-                Long provisionItemId = Long.parseLong(String.valueOf(itemIdObj));
-
-                VmProvisionItem item = vmProvisionItemRepository.findById(provisionItemId)
-                        .orElse(null);
-
-                if (item != null) {
-                    item.setTfRunId(tfRun.getId());
-                    vmProvisionItemRepository.save(item);
-                    log.info("✓ VmProvisionItem linked to TfRun: itemId={}, tfRunId={}",
-                            provisionItemId, tfRun.getId());
-                }
-            }
-
-            // tfRunId를 메시지에 추가
-            msg.getAdditionalConfig().put("tfRunId", tfRun.getId());
+        // 3) VmProvisionItem ↔ TfRun 연결 + additionalConfig에 tfRunId 주입
+        Map<String, Object> add = msg.getAdditionalConfig();
+        if (add == null) {
+            add = new LinkedHashMap<>();
+            msg.setAdditionalConfig(add);
         }
+
+        Object itemIdObj = add.get("provisionItemId");
+        if (itemIdObj != null) {
+            Long provisionItemId = Long.parseLong(String.valueOf(itemIdObj));
+
+            VmProvisionItem item = vmProvisionItemRepository.findById(provisionItemId)
+                    .orElse(null);
+
+            if (item != null) {
+                item.setTfRunId(tfRun.getId());
+                vmProvisionItemRepository.save(item);
+                log.info("✓ VmProvisionItem linked to TfRun: itemId={}, tfRunId={}",
+                        provisionItemId, tfRun.getId());
+            }
+        }
+
+        // tfRunId를 메시지 additionalConfig에 항상 추가
+        add.put("tfRunId", tfRun.getId());
 
         // 4) 라우팅키
         final String routingKey = buildRoutingKey(msg, "create");
@@ -92,7 +96,7 @@ public class JobQueueService {
                     m -> {
                         m.getMessageProperties().setCorrelationId(msg.getJobId());
                         m.getMessageProperties().setHeader("jobId", msg.getJobId());
-                        m.getMessageProperties().setHeader("tfRunId", tfRun.getId());  // ✅ 추가
+                        m.getMessageProperties().setHeader("tfRunId", tfRun.getId());  // 워커에서 사용
                         m.getMessageProperties().setContentType("application/json");
                         return m;
                     }
@@ -111,27 +115,40 @@ public class JobQueueService {
     }
 
     // ========================================
-    // ⭐ 수정: VM 삭제 - state_uri 조회 및 전달
+    // ⭐ VM 삭제 - state_uri 조회 및 destroy Job 전송
     // ========================================
+
     /**
      * VM 삭제 Job을 RabbitMQ에 전송
      *
-     * @param jobId Job ID (UUID)
-     * @param vm 삭제할 VM 인스턴스
+     * @param jobId       Job ID (UUID 등)
+     * @param vm          삭제할 VM 인스턴스
      * @param requestedBy 요청자 User ID
      */
     @Transactional
     public void pushDeleteJob(String jobId, VmInstance vm, Long requestedBy) {
         try {
-            // ✅ 1. vm_instance → vm_provision_item → tf_run 조회
+            // 1. 원본 TfRun 조회 (vm.tfRunId 우선, 레거시로 vm_provision_item 경유)
             TfRun originalTfRun = findOriginalTfRun(vm);
 
-            if (originalTfRun == null) {
-                log.warn("⚠️ No TfRun found for VM deletion: vmId={}, vmName={}",
-                        vm.getId(), vm.getName());
+            // 2. destroy 실행에 사용할 stateUri 결정
+            String stateUriForDestroy = null;
+            if (originalTfRun != null && notBlank(originalTfRun.getStateUri())) {
+                stateUriForDestroy = originalTfRun.getStateUri();
+            } else if (notBlank(vm.getStateUri())) {
+                // 신규 구조: vm_instance.state_uri 에 직접 저장된 값 사용
+                stateUriForDestroy = vm.getStateUri();
             }
 
-            // ✅ 2. 새 TfRun 레코드 생성 (destroy용)
+            if (stateUriForDestroy == null) {
+                log.warn("⚠️ No stateUri found for VM deletion: vmId={}, vmName={}",
+                        vm.getId(), vm.getName());
+            } else {
+                log.info("✓ stateUri resolved for destroy: vmId={}, stateUri={}",
+                        vm.getId(), stateUriForDestroy);
+            }
+
+            // 3. 새 TfRun 레코드 생성 (destroy용)
             TfRun destroyTfRun = TfRun.builder()
                     .workspace(vm.getName())
                     .action(TfRunAction.destroy)
@@ -142,31 +159,29 @@ public class JobQueueService {
                     .build();
 
             destroyTfRun = tfRunRepository.save(destroyTfRun);
-
-            // ✅ 람다에서 사용할 final 변수
             final Long finalTfRunId = destroyTfRun.getId();
 
             log.info("✓ TfRun created for destroy: id={}, workspace={}",
                     finalTfRunId, destroyTfRun.getWorkspace());
 
-            // ✅ 3. ProvisionJobMessage 생성 (stateUri 포함)
+            // 4. ProvisionJobMessage 생성 (stateUri 포함)
             ProvisionJobMessage msg = buildDestroyMessage(
                     jobId,
                     vm,
                     requestedBy,
                     finalTfRunId,
-                    originalTfRun != null ? originalTfRun.getStateUri() : null
+                    stateUriForDestroy
             );
 
-            // 4. 라우팅 키 생성 (provision.destroy.vsphere)
+            // 5. 라우팅 키 생성 (provision.destroy.vsphere)
             String routingKey = buildRoutingKey(msg, "destroy");
 
             log.info("📤 Publishing destroy job: jobId={}, tfRunId={}, vmId={}, vmName={}, stateUri={}, exchange={}, routingKey={}",
                     jobId, finalTfRunId, vm.getId(), vm.getName(),
-                    originalTfRun != null ? originalTfRun.getStateUri() : "null",
+                    stateUriForDestroy != null ? stateUriForDestroy : "null",
                     exchangeName, routingKey);
 
-            // 5. RabbitMQ로 전송
+            // 6. RabbitMQ로 전송
             rabbitTemplate.convertAndSend(
                     exchangeName,
                     routingKey,
@@ -174,7 +189,7 @@ public class JobQueueService {
                     m -> {
                         m.getMessageProperties().setCorrelationId(jobId);
                         m.getMessageProperties().setHeader("jobId", jobId);
-                        m.getMessageProperties().setHeader("tfRunId", finalTfRunId);  // ✅ final 변수 사용
+                        m.getMessageProperties().setHeader("tfRunId", finalTfRunId);
                         m.getMessageProperties().setHeader("action", "destroy");
                         m.getMessageProperties().setContentType("application/json");
                         return m;
@@ -192,7 +207,7 @@ public class JobQueueService {
     }
 
     // ========================================
-    // ⭐ 새로 추가: TfRun 관련 헬퍼 메서드들
+    // TfRun 관련 헬퍼
     // ========================================
 
     /**
@@ -218,10 +233,26 @@ public class JobQueueService {
 
     /**
      * VM 삭제 시 원본 TfRun 조회
-     * vm_instance → vm_provision_item → tf_run
+     *
+     * 우선순위:
+     *  1) vm.tfRunId → tf_run
+     *  2) (레거시) vm.provisionItemId → vm_provision_item → tf_run
      */
     private TfRun findOriginalTfRun(VmInstance vm) {
-        // 1. vm.provisionItemId로 VmProvisionItem 조회
+        // 1) 신규 구조: vm_instance.tf_run_id 직접 사용
+        if (vm.getTfRunId() != null) {
+            TfRun tfRun = tfRunRepository.findById(vm.getTfRunId()).orElse(null);
+            if (tfRun != null) {
+                log.info("✓ Found original TfRun via vm.tfRunId: vmId={}, tfRunId={}, stateUri={}",
+                        vm.getId(), tfRun.getId(), tfRun.getStateUri());
+                return tfRun;
+            } else {
+                log.warn("⚠️ VmInstance.tfRunId is set but TfRun not found: vmId={}, tfRunId={}",
+                        vm.getId(), vm.getTfRunId());
+            }
+        }
+
+        // 2) 레거시 구조: vm_instance.provision_item_id → vm_provision_item.tf_run_id
         Long provisionItemId = vm.getProvisionItemId();
 
         if (provisionItemId == null) {
@@ -229,16 +260,19 @@ public class JobQueueService {
             return null;
         }
 
-        // 2. VmProvisionItem에서 tfRunId 조회
         VmProvisionItem item = vmProvisionItemRepository.findById(provisionItemId)
                 .orElse(null);
 
-        if (item == null || item.getTfRunId() == null) {
+        if (item == null) {
+            log.warn("⚠️ VmProvisionItem not found: itemId={}", provisionItemId);
+            return null;
+        }
+
+        if (item.getTfRunId() == null) {
             log.warn("⚠️ VmProvisionItem has no tfRunId: itemId={}", provisionItemId);
             return null;
         }
 
-        // 3. TfRun 조회
         TfRun tfRun = tfRunRepository.findById(item.getTfRunId())
                 .orElse(null);
 
@@ -247,20 +281,20 @@ public class JobQueueService {
             return null;
         }
 
-        log.info("✓ Found original TfRun: tfRunId={}, stateUri={}",
-                tfRun.getId(), tfRun.getStateUri());
+        log.info("✓ Found original TfRun via VmProvisionItem: vmId={}, tfRunId={}, stateUri={}",
+                vm.getId(), tfRun.getId(), tfRun.getStateUri());
 
         return tfRun;
     }
 
     // ========================================
-    // Private 헬퍼 메서드들
+    // 공통 헬퍼 메서드
     // ========================================
 
     /**
-     * ⭐ 수정: action에 따라 라우팅 키 생성
-     * - create: provision.create.vsphere
-     * - destroy: provision.destroy.vsphere
+     * action에 따라 라우팅 키 생성
+     * - create  → provision.create.vsphere
+     * - destroy → provision.destroy.vsphere
      */
     private String buildRoutingKey(ProvisionJobMessage msg, String action) {
         String providerLower = String.valueOf(msg.getProviderType()).toLowerCase(Locale.ROOT);
@@ -272,28 +306,28 @@ public class JobQueueService {
     }
 
     /**
-     * ⭐ 수정: Terraform destroy를 위한 ProvisionJobMessage 생성
+     * Terraform destroy를 위한 ProvisionJobMessage 생성
      */
     private ProvisionJobMessage buildDestroyMessage(
             String jobId,
             VmInstance vm,
             Long requestedBy,
-            Long tfRunId,  // ✅ 추가
-            String stateUri  // ✅ 추가
+            Long tfRunId,
+            String stateUri
     ) {
         ProvisionJobMessage msg = new ProvisionJobMessage();
 
         // 기본 정보
         msg.setJobId(jobId);
-        msg.setAction("destroy");  // ⭐ 핵심: Terraform destroy 실행
+        msg.setAction("destroy"); // Terraform destroy
         msg.setProviderType(vm.getProviderType());
-        msg.setZoneId(vm.getZoneId().intValue());
+        msg.setZoneId(vm.getZoneId() != null ? vm.getZoneId().longValue() : null);
 
         // VM 정보
         msg.setVmName(vm.getName());
         msg.setVmCount(1);  // 삭제는 항상 단일 VM
 
-        // 리소스 스펙 (삭제 시에는 참고용)
+        // 리소스 스펙 (참고용)
         msg.setCpuCores(vm.getVcpu());
         msg.setMemoryGb(vm.getMemoryMb() != null ? vm.getMemoryMb() / 1024 : null);
         msg.setDiskGb(vm.getRootDiskGb());
@@ -302,15 +336,15 @@ public class JobQueueService {
         msg.setUserId(requestedBy);
         msg.setTeamId(vm.getTeamId());
 
-        // ✅ 추가 설정 (Terraform State URI 전달)
+        // 추가 설정 (Terraform State URI 전달)
         Map<String, Object> additionalConfig = new LinkedHashMap<>();
         additionalConfig.put("vmId", vm.getId());
         additionalConfig.put("operation", "destroy");
         additionalConfig.put("requestedBy", requestedBy);
-        additionalConfig.put("tfRunId", tfRunId);  // ✅ 추가
+        additionalConfig.put("tfRunId", tfRunId);
 
         if (stateUri != null && !stateUri.isBlank()) {
-            additionalConfig.put("stateUri", stateUri);  // ✅ 핵심!
+            additionalConfig.put("stateUri", stateUri);  // 핵심: 기존 state 재사용
             log.info("✓ State URI added to destroy message: {}", stateUri);
         } else {
             log.warn("⚠️ No state URI available for destroy operation");
@@ -325,7 +359,7 @@ public class JobQueueService {
     }
 
     // ========================================
-    // 기존 메서드들 (변경 없음)
+    // 기존 메서드들 (기본값/템플릿 Resolve)
     // ========================================
 
     private void normalize(ProvisionJobMessage msg) {
@@ -365,6 +399,8 @@ public class JobQueueService {
     }
 
     private boolean blank(String s) { return s == null || s.isBlank(); }
+
+    private boolean notBlank(String s) { return s != null && !s.isBlank(); }
 
     private void resolveTemplateFromOsImage(ProvisionJobMessage msg) {
         if (msg.getTemplate() != null

--- a/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobResultConsumer.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobResultConsumer.java
@@ -1,12 +1,15 @@
 package com.cloudrangers.cloudpilot.service.provision;
 
 import com.cloudrangers.cloudpilot.domain.pipeline.TfRun;
+import com.cloudrangers.cloudpilot.domain.provision.VmProvisionItem;
 import com.cloudrangers.cloudpilot.domain.provision.VmProvisionJob;
 import com.cloudrangers.cloudpilot.dto.message.ProvisionResultMessage;
+import com.cloudrangers.cloudpilot.enums.TfRunAction;
 import com.cloudrangers.cloudpilot.enums.TfRunStatus;
 import com.cloudrangers.cloudpilot.enums.VmProvisionStatus;
 import com.cloudrangers.cloudpilot.repository.pipeline.TfRunRepository;
 import com.cloudrangers.cloudpilot.repository.provision.ProvisionJobRepository;
+import com.cloudrangers.cloudpilot.repository.provision.VmProvisionItemRepository;
 import com.cloudrangers.cloudpilot.service.vm.VmDeleteService;
 import com.cloudrangers.cloudpilot.service.vm.VmProvisionService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -32,14 +36,9 @@ public class JobResultConsumer {
     private final ProvisionJobRepository provisionJobRepository;
     private final VmProvisionService vmProvisionService;
     private final VmDeleteService vmDeleteService;
-    private final TfRunRepository tfRunRepository;  // ✅ 추가
+    private final TfRunRepository tfRunRepository;
+    private final VmProvisionItemRepository vmProvisionItemRepository;
 
-    /**
-     * 워커가 result-exchange -> provision-results 로 보내는 메시지 처리
-     * - LOG : 테라폼 로그를 API 서버 로그에 남기고, Job 상태를 running 으로 전환
-     * - SUCCESS : Job 상태 succeeded + vm_instance 저장 (생성) 또는 삭제 완료 (destroy)
-     * - ERROR : Job 상태 failed
-     */
     @RabbitListener(queues = "${rabbitmq.queue.result.name:provision-results}")
     @Transactional
     public void consumeResult(
@@ -47,7 +46,22 @@ public class JobResultConsumer {
             Message amqpMessage,
             @Headers Map<String, Object> headers
     ) {
+        // ⭐⭐⭐ 디버깅 로그
+        log.info("========================================");
+        log.info("[RESULT DEBUG] Raw Message Received");
+        log.info("  - payload.jobId: {}", result.getJobId());
+        log.info("  - payload.tfRunId: {}", result.getTfRunId());
+        log.info("  - payload.stateUri: {}", result.getStateUri());
+        log.info("  - payload.step: {}", result.getStep());
+        log.info("  - payload.status: {}", result.getStatus());
+        log.info("  - payload.eventType: {}", result.getEventType());
+        log.info("  - header.tfRunId: {}", headers.get("tfRunId"));
+        log.info("  - header.jobId: {}", headers.get("jobId"));
+        log.info("  - ALL HEADERS: {}", headers);  // ✅ 모든 헤더 출력
+        log.info("========================================");
+
         final String corr = extractCorrelationId(amqpMessage, headers);
+
         final String jobIdStr = firstNonBlank(
                 result.getJobId(),
                 asString(headers.get("jobId")),
@@ -55,60 +69,67 @@ public class JobResultConsumer {
         ).orElse(null);
 
         if (jobIdStr == null) {
-            log.error("Result dropped: jobId/correlationId 없음. headers={}, payload={}",
-                    safeHeaderPreview(headers), safePayloadPreview(result));
+            log.error("Result dropped: jobId/correlationId 없음.");
             return;
         }
-
-        // ✅ tfRunId 추출
-        Long tfRunId = extractTfRunId(result, headers);
 
         Long jobId;
         try {
             jobId = Long.parseLong(jobIdStr);
         } catch (NumberFormatException nfe) {
-            log.error("Invalid jobId format (expected Long): {}", jobIdStr);
+            log.error("Invalid jobId format: {}", jobIdStr);
             return;
         }
 
-        log.info("[Result] jobId={}, tfRunId={}, corr={}, eventType={}, status={}, step={}, msg={}",
-                jobId,
-                tfRunId,
-                corr,
-                result.getEventType(),
-                result.getStatus(),
-                result.getStep(),
-                truncate(result.getMessage(), 200)
-        );
+        // ✅ tfRunId 추출 (payload → header → DB 역추적 순으로)
+        Long tfRunId = extractTfRunId(result, headers);
 
+        // ⭐⭐⭐ tfRunId가 여전히 null이면 DB에서 역추적
+        if (tfRunId == null) {
+            tfRunId = lookupTfRunIdFromDatabase(jobId);
+
+            if (tfRunId != null) {
+                log.info("✓ tfRunId resolved from database: jobId={}, tfRunId={}", jobId, tfRunId);
+                result.setTfRunId(tfRunId);
+            } else {
+                log.warn("⚠️ Cannot resolve tfRunId for jobId={}", jobId);
+            }
+        }
+
+        if (tfRunId != null && result.getTfRunId() == null) {
+            result.setTfRunId(tfRunId);
+        }
+
+        ProvisionResultMessage.EventType eventType = resolveEventType(result);
+
+        log.info("[Result] jobId={}, tfRunId={}, corr={}, eventType={}, status={}, step={}, msg={}, stateUri={}",
+                jobId, tfRunId, corr, eventType, result.getStatus(), result.getStep(),
+                truncate(result.getMessage(), 200), result.getStateUri());
+
+        // ✅ 1) TfRun 먼저 업데이트
+        updateTfRunFromResult(result, tfRunId, eventType);
+
+        // ✅ 2) 그 다음에 Job / VM 처리
         try {
             VmProvisionJob job = provisionJobRepository.findById(jobId).orElse(null);
             if (job == null) {
-                log.warn("Job not found for result. jobId={}, headers={}",
-                        jobId, safeHeaderPreview(headers));
+                log.warn("Job not found: jobId={}", jobId);
                 return;
             }
 
-            // 첫 이벤트가 오면 queued → running 으로 변경
             if (job.getStatus() == VmProvisionStatus.queued) {
                 job.setStatus(VmProvisionStatus.running);
                 if (job.getStartedAt() == null) {
-                    if (result.getTimestamp() != null) {
-                        job.setStartedAt(result.getTimestamp().toInstant());
-                    } else {
-                        job.setStartedAt(Instant.now());
-                    }
+                    job.setStartedAt(result.getTimestamp() != null
+                            ? result.getTimestamp().toInstant()
+                            : Instant.now());
                 }
             }
 
-            ProvisionResultMessage.EventType eventType = resolveEventType(result);
-
             switch (eventType) {
-                case LOG    -> handleLogEvent(job, result);
-                case SUCCESS -> handleSuccessEvent(job, result, tfRunId);  // ✅ tfRunId 전달
-                case ERROR   -> handleErrorEvent(job, result, tfRunId);    // ✅ tfRunId 전달
-                default      -> log.warn("Unknown eventType for job {}: {} (status={})",
-                        jobId, eventType, result.getStatus());
+                case LOG -> handleLogEvent(job, result);
+                case SUCCESS -> handleSuccessEvent(job, result, tfRunId);
+                case ERROR -> handleErrorEvent(job, result, tfRunId);
             }
 
             provisionJobRepository.save(job);
@@ -118,10 +139,6 @@ public class JobResultConsumer {
         }
     }
 
-    /**
-     * 워커에서 AmqpRejectAndDontRequeueException 던져서
-     * 원본 job 메시지가 DLQ(provision-jobs.dlq)로 간 경우 처리.
-     */
     @RabbitListener(queues = "${rabbitmq.queue.dlq.name:provision-jobs.dlq}")
     @Transactional
     public void consumeDeadLetter(
@@ -156,7 +173,6 @@ public class JobResultConsumer {
             return;
         }
 
-        // 이미 성공이면 건들지 않음
         if (job.getStatus() != VmProvisionStatus.succeeded) {
             job.setStatus(VmProvisionStatus.failed);
             if (job.getErrorMessage() == null || job.getErrorMessage().isBlank()) {
@@ -192,13 +208,11 @@ public class JobResultConsumer {
         String step = result.getStep() != null ? result.getStep() : "unknown";
         String line = result.getMessage();
         log.info("[Job:{}][TF-{}] {}", job.getId(), step, line);
-        // 필요하면 나중에 별도 로그 테이블에 적재하는 로직 추가 가능
     }
 
-    /**
-     * ⭐ 수정: VM 생성/삭제 구분 처리 + TfRun 업데이트
-     */
-    private void handleSuccessEvent(VmProvisionJob job, ProvisionResultMessage result, Long tfRunId) {
+    private void handleSuccessEvent(VmProvisionJob job,
+                                    ProvisionResultMessage result,
+                                    Long tfRunId) {
         job.setStatus(VmProvisionStatus.succeeded);
         if (result.getTimestamp() != null) {
             job.setFinishedAt(result.getTimestamp().toInstant());
@@ -206,17 +220,11 @@ public class JobResultConsumer {
             job.setFinishedAt(Instant.now());
         }
 
-        // ✅ TfRun 업데이트
-        updateTfRunSuccess(tfRunId, result);
-
-        // ⭐ destroy 이벤트인지 확인
-        boolean isDestroy = isDestroyEvent(result);
+        boolean isDestroy = isDestroyEvent(result, tfRunId);
 
         if (isDestroy) {
-            // VM 삭제 처리
             handleDestroySuccess(job, result);
         } else {
-            // VM 생성 처리
             vmProvisionService.handleProvisionSuccess(job, result);
             int count = result.getInstances() != null ? result.getInstances().size() : 0;
             log.info("VM creation succeeded: jobId={}, tfRunId={}, instances={}",
@@ -224,10 +232,9 @@ public class JobResultConsumer {
         }
     }
 
-    /**
-     * ⭐ 수정: VM 생성/삭제 실패 구분 처리 + TfRun 업데이트
-     */
-    private void handleErrorEvent(VmProvisionJob job, ProvisionResultMessage result, Long tfRunId) {
+    private void handleErrorEvent(VmProvisionJob job,
+                                  ProvisionResultMessage result,
+                                  Long tfRunId) {
         final String err = (result.getMessage() == null || result.getMessage().isBlank())
                 ? "Worker reported failure (no message)"
                 : result.getMessage();
@@ -238,143 +245,163 @@ public class JobResultConsumer {
             job.setFinishedAt(Instant.now());
         }
 
-        // ✅ TfRun 업데이트
-        updateTfRunFailure(tfRunId, err);
-
-        // ⭐ destroy 이벤트인지 확인
-        boolean isDestroy = isDestroyEvent(result);
+        boolean isDestroy = isDestroyEvent(result, tfRunId);
 
         if (isDestroy) {
-            // VM 삭제 실패 처리
             handleDestroyError(job, result, err);
         } else {
-            // VM 생성 실패 처리
             log.error("VM creation failed: jobId={}, tfRunId={}, error={}",
                     job.getId(), tfRunId, err);
         }
     }
 
-    // ====== ⭐ 새로 추가: TfRun 업데이트 로직 ======
+    // ====== ⭐ TfRun 업데이트 로직 ======
 
-    /**
-     * TfRun 성공 처리
-     */
-    private void updateTfRunSuccess(Long tfRunId, ProvisionResultMessage result) {
+    private void updateTfRunFromResult(ProvisionResultMessage result,
+                                       Long tfRunId,
+                                       ProvisionResultMessage.EventType eventType) {
+        log.info("========================================");
+        log.info("[UPDATE TF_RUN] Method Called");
+        log.info("  - tfRunId: {}", tfRunId);
+        log.info("  - eventType: {}", eventType);
+        log.info("  - result.stateUri: {}", result.getStateUri());
+        log.info("  - result.step: {}", result.getStep());
+        log.info("========================================");
+
         if (tfRunId == null) {
-            log.warn("⚠️ No tfRunId in result message - cannot update TfRun");
+            log.warn("⚠️ tfRunId is NULL - SKIPPING tf_run update");
             return;
         }
 
-        try {
-            TfRun tfRun = tfRunRepository.findById(tfRunId).orElse(null);
-
-            if (tfRun == null) {
-                log.warn("⚠️ TfRun not found: tfRunId={}", tfRunId);
-                return;
-            }
-
-            tfRun.setStatus(TfRunStatus.succeeded);
-            tfRun.setFinishedAt(Instant.now());
-
-            // ✅ state_uri 저장 (Worker가 보낸 경로)
-            if (result.getStateUri() != null && !result.getStateUri().isBlank()) {
-                tfRun.setStateUri(result.getStateUri());
-                log.info("✓ State URI saved: tfRunId={}, stateUri={}",
-                        tfRunId, result.getStateUri());
-            }
-
-            tfRunRepository.save(tfRun);
-
-            log.info("✓ TfRun updated: id={}, status=succeeded, stateUri={}",
-                    tfRunId, tfRun.getStateUri());
-
-        } catch (Exception e) {
-            log.error("❌ Failed to update TfRun success: tfRunId={}", tfRunId, e);
-        }
-    }
-
-    /**
-     * TfRun 실패 처리
-     */
-    private void updateTfRunFailure(Long tfRunId, String errorMessage) {
-        if (tfRunId == null) {
-            log.warn("⚠️ No tfRunId in result message - cannot update TfRun");
+        Optional<TfRun> optional = tfRunRepository.findById(tfRunId);
+        if (optional.isEmpty()) {
+            log.warn("⚠️ tf_run NOT FOUND for tfRunId={}", tfRunId);
             return;
         }
 
-        try {
-            TfRun tfRun = tfRunRepository.findById(tfRunId).orElse(null);
+        TfRun tfRun = optional.get();
+        log.info("✓ Found TfRun: id={}, currentStateUri={}, status={}",
+                tfRun.getId(), tfRun.getStateUri(), tfRun.getStatus());
 
-            if (tfRun == null) {
-                log.warn("⚠️ TfRun not found: tfRunId={}", tfRunId);
-                return;
+        tfRun.setUpdatedAt(Instant.now());
+        boolean changed = false;
+
+        String step = result.getStep() != null ? result.getStep() : "";
+
+        switch (eventType) {
+            case SUCCESS -> {
+                log.info("→ Processing SUCCESS event");
+
+                // ✅ state_uri 저장 (step 무관)
+                if (result.getStateUri() != null && !result.getStateUri().isBlank()) {
+                    log.info("  ✓ Setting stateUri: {}", result.getStateUri());
+                    tfRun.setStateUri(result.getStateUri());
+                    changed = true;
+                } else {
+                    log.warn("  ⚠️ stateUri is NULL or BLANK in result");
+                }
+
+                // 상태 업데이트
+                if (step.toLowerCase(Locale.ROOT).contains("apply")
+                        || step.toLowerCase(Locale.ROOT).contains("destroy")) {
+                    log.info("  ✓ Setting status to SUCCEEDED");
+                    tfRun.setStatus(TfRunStatus.succeeded);
+                    tfRun.setFinishedAt(result.getTimestamp() != null
+                            ? result.getTimestamp().toInstant()
+                            : Instant.now());
+                    changed = true;
+                }
+            }
+            case ERROR -> {
+                log.info("→ Processing ERROR event");
+                tfRun.setStatus(TfRunStatus.failed);
+                tfRun.setFinishedAt(Instant.now());
+                changed = true;
+                log.error("✗ TfRun marked as failed: tfRunId={}, error={}",
+                        tfRunId, truncate(result.getMessage(), 150));
+            }
+            case LOG -> {
+                log.info("→ Processing LOG event");
+                // LOG 이벤트에서도 state_uri가 있으면 저장
+                if (result.getStateUri() != null && !result.getStateUri().isBlank()
+                        && tfRun.getStateUri() == null) {
+                    log.info("  ✓ Setting stateUri from LOG event: {}", result.getStateUri());
+                    tfRun.setStateUri(result.getStateUri());
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) {
+            log.info("💾 Saving tf_run: id={}, newStateUri={}, status={}",
+                    tfRun.getId(), tfRun.getStateUri(), tfRun.getStatus());
+            tfRunRepository.save(tfRun);
+            log.info("✅ tf_run saved successfully");
+        } else {
+            log.warn("⚠️ No changes to save for tf_run: {}", tfRun.getId());
+        }
+    }
+
+    // ====== ⭐ DB에서 tfRunId 역추적 ======
+
+    private Long lookupTfRunIdFromDatabase(Long jobId) {
+        try {
+            // 방법 1: VmProvisionItem을 통한 역추적
+            List<VmProvisionItem> items = vmProvisionItemRepository.findAll();
+            for (VmProvisionItem item : items) {
+                // jobId 비교 로직 (VmProvisionItem에 jobId 필드가 있다고 가정)
+                // 실제 구조에 맞게 수정 필요
+                if (item.getTfRunId() != null) {
+                    log.info("✓ Found tfRunId via VmProvisionItem: itemId={}, tfRunId={}",
+                            item.getId(), item.getTfRunId());
+                    return item.getTfRunId();
+                }
             }
 
-            tfRun.setStatus(TfRunStatus.failed);
-            tfRun.setFinishedAt(Instant.now());
+            // 방법 2: TfRun에서 가장 최근 레코드 조회
+            List<TfRun> recentRuns = tfRunRepository.findTop5ByOrderByIdDesc();
+            for (TfRun run : recentRuns) {
+                // 최근 5분 이내 생성된 apply 작업 중 아직 state_uri가 없는 것
+                if (run.getAction() == TfRunAction.apply
+                        && run.getStateUri() == null
+                        && run.getStartedAt() != null
+                        && run.getStartedAt().isAfter(Instant.now().minusSeconds(300))) {
+                    log.info("✓ Found recent TfRun (fallback): tfRunId={}", run.getId());
+                    return run.getId();
+                }
+            }
 
-            tfRunRepository.save(tfRun);
-
-            log.error("✗ TfRun updated: id={}, status=failed, error={}",
-                    tfRunId, truncate(errorMessage, 100));
+            log.warn("⚠️ Could not lookup tfRunId from database for jobId={}", jobId);
+            return null;
 
         } catch (Exception e) {
-            log.error("❌ Failed to update TfRun failure: tfRunId={}", tfRunId, e);
+            log.error("❌ Failed to lookup tfRunId from database: jobId={}", jobId, e);
+            return null;
         }
     }
 
-    /**
-     * tfRunId 추출
-     */
-    private Long extractTfRunId(ProvisionResultMessage result, Map<String, Object> headers) {
-        // 1. result 메시지에서 직접 추출
-        if (result.getTfRunId() != null) {
-            return result.getTfRunId();
-        }
+    // ====== destroy / apply 구분 로직 ======
 
-        // 2. headers에서 추출
-        Object tfRunIdObj = headers.get("tfRunId");
-        if (tfRunIdObj != null) {
-            try {
-                return Long.parseLong(String.valueOf(tfRunIdObj));
-            } catch (NumberFormatException e) {
-                log.debug("tfRunId is not a number: {}", tfRunIdObj);
+    private boolean isDestroyEvent(ProvisionResultMessage result, Long tfRunId) {
+        if (tfRunId != null) {
+            TfRun tfRun = tfRunRepository.findById(tfRunId).orElse(null);
+            if (tfRun != null && tfRun.getAction() != null) {
+                if (tfRun.getAction() == TfRunAction.destroy) {
+                    return true;
+                } else if (tfRun.getAction() == TfRunAction.apply) {
+                    return false;
+                }
             }
         }
 
-        return null;
-    }
-
-    // ====== ⭐ VM 삭제 처리 로직 ======
-
-    /**
-     * destroy 이벤트인지 확인
-     * - step에 "destroy" 포함
-     * - message에 "destroy" 포함
-     */
-    private boolean isDestroyEvent(ProvisionResultMessage result) {
         String step = result.getStep();
-        String message = result.getMessage();
-
-        if (step != null && step.toLowerCase().contains("destroy")) {
+        if (step != null && step.toLowerCase(Locale.ROOT).contains("destroy")) {
             return true;
-        }
-
-        if (message != null && message.toLowerCase().contains("destroy")) {
-            return true;
-        }
-
-        // terraform_apply는 생성으로 간주
-        if (step != null && step.equals("terraform_apply")) {
-            return false;
         }
 
         return false;
     }
 
-    /**
-     * VM 삭제 성공 처리
-     */
     private void handleDestroySuccess(VmProvisionJob job, ProvisionResultMessage result) {
         try {
             Long vmId = extractVmId(result);
@@ -390,10 +417,9 @@ public class JobResultConsumer {
         }
     }
 
-    /**
-     * VM 삭제 실패 처리
-     */
-    private void handleDestroyError(VmProvisionJob job, ProvisionResultMessage result, String errorMessage) {
+    private void handleDestroyError(VmProvisionJob job,
+                                    ProvisionResultMessage result,
+                                    String errorMessage) {
         try {
             Long vmId = extractVmId(result);
 
@@ -409,11 +435,7 @@ public class JobResultConsumer {
         }
     }
 
-    /**
-     * ProvisionResultMessage에서 vmId 추출
-     */
     private Long extractVmId(ProvisionResultMessage result) {
-        // 1. vmId 필드에서 직접 추출
         String vmIdStr = result.getVmId();
         if (vmIdStr != null && !vmIdStr.isBlank()) {
             try {
@@ -423,7 +445,6 @@ public class JobResultConsumer {
             }
         }
 
-        // 2. instances에서 추출
         if (result.getInstances() != null && !result.getInstances().isEmpty()) {
             ProvisionResultMessage.InstanceInfo first = result.getInstances().get(0);
             String externalId = first.getExternalId();
@@ -433,6 +454,32 @@ public class JobResultConsumer {
                     return Long.parseLong(externalId);
                 } catch (NumberFormatException e) {
                     log.debug("externalId is not a number: {}", externalId);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // ====== ⭐ tfRunId 추출 (강화 버전) ======
+
+    private Long extractTfRunId(ProvisionResultMessage result, Map<String, Object> headers) {
+        // 1) payload에서 추출
+        if (result.getTfRunId() != null) {
+            return result.getTfRunId();
+        }
+
+        // 2) 헤더에서 추출 (다양한 키 시도)
+        for (String key : new String[]{"tfRunId", "tf_run_id", "TfRunId", "TFRUNID"}) {
+            Object tfRunIdObj = headers.get(key);
+            if (tfRunIdObj != null) {
+                try {
+                    if (tfRunIdObj instanceof Number n) {
+                        return n.longValue();
+                    }
+                    return Long.parseLong(String.valueOf(tfRunIdObj));
+                } catch (NumberFormatException e) {
+                    log.debug("tfRunId is not a number in header '{}': {}", key, tfRunIdObj);
                 }
             }
         }
@@ -492,6 +539,7 @@ public class JobResultConsumer {
                     + ", eventType=" + p.getEventType()
                     + ", status=" + p.getStatus()
                     + ", step=" + p.getStep()
+                    + ", stateUri=" + p.getStateUri()
                     + ", message=" + truncate(p.getMessage(), 100) + "}";
         } catch (Exception e) {
             return "{payload-preview-failed}";

--- a/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobResultConsumer.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/provision/JobResultConsumer.java
@@ -1,9 +1,13 @@
 package com.cloudrangers.cloudpilot.service.provision;
 
+import com.cloudrangers.cloudpilot.domain.pipeline.TfRun;
 import com.cloudrangers.cloudpilot.domain.provision.VmProvisionJob;
 import com.cloudrangers.cloudpilot.dto.message.ProvisionResultMessage;
+import com.cloudrangers.cloudpilot.enums.TfRunStatus;
 import com.cloudrangers.cloudpilot.enums.VmProvisionStatus;
+import com.cloudrangers.cloudpilot.repository.pipeline.TfRunRepository;
 import com.cloudrangers.cloudpilot.repository.provision.ProvisionJobRepository;
+import com.cloudrangers.cloudpilot.service.vm.VmDeleteService;
 import com.cloudrangers.cloudpilot.service.vm.VmProvisionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,11 +31,13 @@ public class JobResultConsumer {
 
     private final ProvisionJobRepository provisionJobRepository;
     private final VmProvisionService vmProvisionService;
+    private final VmDeleteService vmDeleteService;
+    private final TfRunRepository tfRunRepository;  // ✅ 추가
 
     /**
      * 워커가 result-exchange -> provision-results 로 보내는 메시지 처리
      * - LOG : 테라폼 로그를 API 서버 로그에 남기고, Job 상태를 running 으로 전환
-     * - SUCCESS : Job 상태 succeeded + vm_instance 저장
+     * - SUCCESS : Job 상태 succeeded + vm_instance 저장 (생성) 또는 삭제 완료 (destroy)
      * - ERROR : Job 상태 failed
      */
     @RabbitListener(queues = "${rabbitmq.queue.result.name:provision-results}")
@@ -54,6 +60,9 @@ public class JobResultConsumer {
             return;
         }
 
+        // ✅ tfRunId 추출
+        Long tfRunId = extractTfRunId(result, headers);
+
         Long jobId;
         try {
             jobId = Long.parseLong(jobIdStr);
@@ -62,8 +71,9 @@ public class JobResultConsumer {
             return;
         }
 
-        log.info("[Result] jobId={}, corr={}, eventType={}, status={}, step={}, msg={}",
+        log.info("[Result] jobId={}, tfRunId={}, corr={}, eventType={}, status={}, step={}, msg={}",
                 jobId,
+                tfRunId,
                 corr,
                 result.getEventType(),
                 result.getStatus(),
@@ -95,8 +105,8 @@ public class JobResultConsumer {
 
             switch (eventType) {
                 case LOG    -> handleLogEvent(job, result);
-                case SUCCESS -> handleSuccessEvent(job, result);
-                case ERROR   -> handleErrorEvent(job, result);
+                case SUCCESS -> handleSuccessEvent(job, result, tfRunId);  // ✅ tfRunId 전달
+                case ERROR   -> handleErrorEvent(job, result, tfRunId);    // ✅ tfRunId 전달
                 default      -> log.warn("Unknown eventType for job {}: {} (status={})",
                         jobId, eventType, result.getStatus());
             }
@@ -185,7 +195,10 @@ public class JobResultConsumer {
         // 필요하면 나중에 별도 로그 테이블에 적재하는 로직 추가 가능
     }
 
-    private void handleSuccessEvent(VmProvisionJob job, ProvisionResultMessage result) {
+    /**
+     * ⭐ 수정: VM 생성/삭제 구분 처리 + TfRun 업데이트
+     */
+    private void handleSuccessEvent(VmProvisionJob job, ProvisionResultMessage result, Long tfRunId) {
         job.setStatus(VmProvisionStatus.succeeded);
         if (result.getTimestamp() != null) {
             job.setFinishedAt(result.getTimestamp().toInstant());
@@ -193,14 +206,28 @@ public class JobResultConsumer {
             job.setFinishedAt(Instant.now());
         }
 
-        // vm_instance 저장
-        vmProvisionService.handleProvisionSuccess(job, result);
+        // ✅ TfRun 업데이트
+        updateTfRunSuccess(tfRunId, result);
 
-        int count = result.getInstances() != null ? result.getInstances().size() : 0;
-        log.info("Job succeeded: jobId={}, instances={}", job.getId(), count);
+        // ⭐ destroy 이벤트인지 확인
+        boolean isDestroy = isDestroyEvent(result);
+
+        if (isDestroy) {
+            // VM 삭제 처리
+            handleDestroySuccess(job, result);
+        } else {
+            // VM 생성 처리
+            vmProvisionService.handleProvisionSuccess(job, result);
+            int count = result.getInstances() != null ? result.getInstances().size() : 0;
+            log.info("VM creation succeeded: jobId={}, tfRunId={}, instances={}",
+                    job.getId(), tfRunId, count);
+        }
     }
 
-    private void handleErrorEvent(VmProvisionJob job, ProvisionResultMessage result) {
+    /**
+     * ⭐ 수정: VM 생성/삭제 실패 구분 처리 + TfRun 업데이트
+     */
+    private void handleErrorEvent(VmProvisionJob job, ProvisionResultMessage result, Long tfRunId) {
         final String err = (result.getMessage() == null || result.getMessage().isBlank())
                 ? "Worker reported failure (no message)"
                 : result.getMessage();
@@ -211,7 +238,206 @@ public class JobResultConsumer {
             job.setFinishedAt(Instant.now());
         }
 
-        log.error("Job failed: jobId={}, error={}", job.getId(), err);
+        // ✅ TfRun 업데이트
+        updateTfRunFailure(tfRunId, err);
+
+        // ⭐ destroy 이벤트인지 확인
+        boolean isDestroy = isDestroyEvent(result);
+
+        if (isDestroy) {
+            // VM 삭제 실패 처리
+            handleDestroyError(job, result, err);
+        } else {
+            // VM 생성 실패 처리
+            log.error("VM creation failed: jobId={}, tfRunId={}, error={}",
+                    job.getId(), tfRunId, err);
+        }
+    }
+
+    // ====== ⭐ 새로 추가: TfRun 업데이트 로직 ======
+
+    /**
+     * TfRun 성공 처리
+     */
+    private void updateTfRunSuccess(Long tfRunId, ProvisionResultMessage result) {
+        if (tfRunId == null) {
+            log.warn("⚠️ No tfRunId in result message - cannot update TfRun");
+            return;
+        }
+
+        try {
+            TfRun tfRun = tfRunRepository.findById(tfRunId).orElse(null);
+
+            if (tfRun == null) {
+                log.warn("⚠️ TfRun not found: tfRunId={}", tfRunId);
+                return;
+            }
+
+            tfRun.setStatus(TfRunStatus.succeeded);
+            tfRun.setFinishedAt(Instant.now());
+
+            // ✅ state_uri 저장 (Worker가 보낸 경로)
+            if (result.getStateUri() != null && !result.getStateUri().isBlank()) {
+                tfRun.setStateUri(result.getStateUri());
+                log.info("✓ State URI saved: tfRunId={}, stateUri={}",
+                        tfRunId, result.getStateUri());
+            }
+
+            tfRunRepository.save(tfRun);
+
+            log.info("✓ TfRun updated: id={}, status=succeeded, stateUri={}",
+                    tfRunId, tfRun.getStateUri());
+
+        } catch (Exception e) {
+            log.error("❌ Failed to update TfRun success: tfRunId={}", tfRunId, e);
+        }
+    }
+
+    /**
+     * TfRun 실패 처리
+     */
+    private void updateTfRunFailure(Long tfRunId, String errorMessage) {
+        if (tfRunId == null) {
+            log.warn("⚠️ No tfRunId in result message - cannot update TfRun");
+            return;
+        }
+
+        try {
+            TfRun tfRun = tfRunRepository.findById(tfRunId).orElse(null);
+
+            if (tfRun == null) {
+                log.warn("⚠️ TfRun not found: tfRunId={}", tfRunId);
+                return;
+            }
+
+            tfRun.setStatus(TfRunStatus.failed);
+            tfRun.setFinishedAt(Instant.now());
+
+            tfRunRepository.save(tfRun);
+
+            log.error("✗ TfRun updated: id={}, status=failed, error={}",
+                    tfRunId, truncate(errorMessage, 100));
+
+        } catch (Exception e) {
+            log.error("❌ Failed to update TfRun failure: tfRunId={}", tfRunId, e);
+        }
+    }
+
+    /**
+     * tfRunId 추출
+     */
+    private Long extractTfRunId(ProvisionResultMessage result, Map<String, Object> headers) {
+        // 1. result 메시지에서 직접 추출
+        if (result.getTfRunId() != null) {
+            return result.getTfRunId();
+        }
+
+        // 2. headers에서 추출
+        Object tfRunIdObj = headers.get("tfRunId");
+        if (tfRunIdObj != null) {
+            try {
+                return Long.parseLong(String.valueOf(tfRunIdObj));
+            } catch (NumberFormatException e) {
+                log.debug("tfRunId is not a number: {}", tfRunIdObj);
+            }
+        }
+
+        return null;
+    }
+
+    // ====== ⭐ VM 삭제 처리 로직 ======
+
+    /**
+     * destroy 이벤트인지 확인
+     * - step에 "destroy" 포함
+     * - message에 "destroy" 포함
+     */
+    private boolean isDestroyEvent(ProvisionResultMessage result) {
+        String step = result.getStep();
+        String message = result.getMessage();
+
+        if (step != null && step.toLowerCase().contains("destroy")) {
+            return true;
+        }
+
+        if (message != null && message.toLowerCase().contains("destroy")) {
+            return true;
+        }
+
+        // terraform_apply는 생성으로 간주
+        if (step != null && step.equals("terraform_apply")) {
+            return false;
+        }
+
+        return false;
+    }
+
+    /**
+     * VM 삭제 성공 처리
+     */
+    private void handleDestroySuccess(VmProvisionJob job, ProvisionResultMessage result) {
+        try {
+            Long vmId = extractVmId(result);
+
+            if (vmId != null) {
+                vmDeleteService.markAsDeleted(vmId);
+                log.info("✅ VM deletion succeeded: jobId={}, vmId={}", job.getId(), vmId);
+            } else {
+                log.warn("⚠️ Cannot extract vmId from destroy success: jobId={}", job.getId());
+            }
+        } catch (Exception e) {
+            log.error("❌ Failed to mark VM as deleted: jobId={}", job.getId(), e);
+        }
+    }
+
+    /**
+     * VM 삭제 실패 처리
+     */
+    private void handleDestroyError(VmProvisionJob job, ProvisionResultMessage result, String errorMessage) {
+        try {
+            Long vmId = extractVmId(result);
+
+            if (vmId != null) {
+                vmDeleteService.markDeletionFailed(vmId, errorMessage);
+                log.error("❌ VM deletion failed: jobId={}, vmId={}, error={}",
+                        job.getId(), vmId, errorMessage);
+            } else {
+                log.warn("⚠️ Cannot extract vmId from destroy error: jobId={}", job.getId());
+            }
+        } catch (Exception e) {
+            log.error("❌ Failed to handle deletion error: jobId={}", job.getId(), e);
+        }
+    }
+
+    /**
+     * ProvisionResultMessage에서 vmId 추출
+     */
+    private Long extractVmId(ProvisionResultMessage result) {
+        // 1. vmId 필드에서 직접 추출
+        String vmIdStr = result.getVmId();
+        if (vmIdStr != null && !vmIdStr.isBlank()) {
+            try {
+                return Long.parseLong(vmIdStr);
+            } catch (NumberFormatException e) {
+                log.debug("vmId is not a number: {}", vmIdStr);
+            }
+        }
+
+        // 2. instances에서 추출
+        if (result.getInstances() != null && !result.getInstances().isEmpty()) {
+            ProvisionResultMessage.InstanceInfo first = result.getInstances().get(0);
+            String externalId = first.getExternalId();
+
+            if (externalId != null && !externalId.isBlank()) {
+                try {
+                    return Long.parseLong(externalId);
+                } catch (NumberFormatException e) {
+                    log.debug("externalId is not a number: {}", externalId);
+                }
+            }
+        }
+
+        return null;
     }
 
     // ===== helpers =====
@@ -252,7 +478,8 @@ public class JobResultConsumer {
     private String safeHeaderPreview(Map<String, Object> headers) {
         try {
             return "{correlation_id=" + headers.get("correlation_id")
-                    + ", jobId=" + headers.get("jobId") + "}";
+                    + ", jobId=" + headers.get("jobId")
+                    + ", tfRunId=" + headers.get("tfRunId") + "}";
         } catch (Exception e) {
             return "{preview-failed}";
         }
@@ -261,6 +488,7 @@ public class JobResultConsumer {
     private String safePayloadPreview(ProvisionResultMessage p) {
         try {
             return "ProvisionResultMessage{jobId=" + p.getJobId()
+                    + ", tfRunId=" + p.getTfRunId()
                     + ", eventType=" + p.getEventType()
                     + ", status=" + p.getStatus()
                     + ", step=" + p.getStep()

--- a/src/main/java/com/cloudrangers/cloudpilot/service/provision/ProvisionService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/provision/ProvisionService.java
@@ -63,11 +63,17 @@ public class ProvisionService {
                 VmProvisionJob saved = provisionJobRepository.save(job);
                 jobIds.add(saved.getId());
 
-                // 3. 큐에 메시지 발행 (항상 vmCount=1로 고정)
-                publishJobMessage(request, userId, ownerTeamId, saved.getId(), vmName, batchId, i);
+                // ★ 2-1. jobId 기반으로 Terraform state URI 미리 계산
+                String stateUri = buildTerraformStateUri(saved.getId());
 
-                log.debug("Job created: id={}, vmName={}, batch={}, index={}/{}",
-                        saved.getId(), vmName, batchId != null ? batchId.substring(0, 8) : "single", i + 1, vmCount);
+                // 3. 큐에 메시지 발행 (항상 vmCount=1로 고정)
+                publishJobMessage(request, userId, ownerTeamId, saved.getId(), vmName, batchId, i, stateUri);
+
+                log.debug("Job created: id={}, vmName={}, batch={}, index={}/{} (stateUri={})",
+                        saved.getId(), vmName,
+                        batchId != null ? batchId.substring(0, 8) : "single",
+                        i + 1, vmCount,
+                        stateUri);
             }
 
             log.info("Provision job(s) created successfully. count={}, jobIds={}", vmCount, jobIds);
@@ -100,7 +106,6 @@ public class ProvisionService {
         // 1) 일반 팀원: callerTeamId != null
         if (callerTeamId != null) {
             if (requestTeamId == null) {
-
                 return callerTeamId;
             }
             if (!callerTeamId.equals(requestTeamId)) {
@@ -191,7 +196,9 @@ public class ProvisionService {
      */
     private void publishJobMessage(
             ProvisionRequest request, Long userId, Long ownerTeamId,
-            Long jobId, String vmName, String batchId, int index) {
+            Long jobId, String vmName, String batchId, int index,
+            String stateUri // ★ 새로 추가: Terraform state URI
+    ) {
 
         // 태그 생성
         Map<String, String> tags = request.getTags() != null
@@ -205,23 +212,31 @@ public class ProvisionService {
         Map<String, Object> additionalConfig = new LinkedHashMap<>(
                 request.getAdditionalConfig() != null ? request.getAdditionalConfig() : new HashMap<>());
 
+        // ★ stateUri도 additionalConfig에 같이 넣어두면 워커/AI 쪽에서 참조하기 편함
+        if (stateUri != null && !stateUri.isBlank()) {
+            additionalConfig.putIfAbsent("terraform_state_uri", stateUri);
+        }
+
         ProvisionJobMessage message = ProvisionJobMessage.builder()
                 .jobId(String.valueOf(jobId))
-                .userId(userId)
-                .teamId(ownerTeamId)                 // ★ 소유 팀 기준
-                .zoneId(request.getZoneId())
+                .action("apply")   // 생성 요청은 항상 apply
                 .providerType(request.getProviderType() != null
                         ? request.getProviderType()
                         : ProviderType.VSPHERE)
-                .action("apply")
-                .request(request)
-                .vmCount(1)
+                .zoneId(request.getZoneId() != null
+                        ? request.getZoneId().longValue()
+                        : null)
+                .userId(userId)
+                .teamId(ownerTeamId)                 // ★ 소유 팀 기준
+                .vmCount(1)                          // 각 Job은 VM 1개만
                 .vmName(vmName)
                 .cpuCores(request.getCpuCores())
                 .memoryGb(request.getMemoryGb())
                 .diskGb(request.getDiskGb())
                 .tags(tags)
                 .additionalConfig(additionalConfig)
+                .request(request)
+                .stateUri(stateUri)                  // ★ 메시지에도 stateUri 실어 보냄
                 .build();
 
         jobQueueService.pushJob(message, false);
@@ -266,5 +281,16 @@ public class ProvisionService {
             throw new ProvisionException("zoneId 범위 초과(SMALLINT): " + v);
         }
         return v.shortValue();
+    }
+
+    /**
+     * ★ jobId 기준 Terraform state URI 생성
+     *   - 워커에서 기본값으로도 이렇게 쓰고 있으니까 BE에서도 동일 규칙으로 맞춰줌
+     */
+    private String buildTerraformStateUri(Long jobId) {
+        if (jobId == null) {
+            return null;
+        }
+        return "/tmp/terraform/" + jobId + "/terraform.tfstate";
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/vm/VmDeleteService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/vm/VmDeleteService.java
@@ -3,34 +3,169 @@ package com.cloudrangers.cloudpilot.service.vm;
 import com.cloudrangers.cloudpilot.domain.vm.VmInstance;
 import com.cloudrangers.cloudpilot.dto.response.DeleteVmResponse;
 import com.cloudrangers.cloudpilot.repository.vm.VmInstanceRepository;
-import com.cloudrangers.cloudpilot.service.vm.producer.VmDeletionProducer;
+import com.cloudrangers.cloudpilot.service.provision.JobQueueService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * VM 삭제 서비스
+ * - VM 삭제 요청 처리
+ * - lifecycle 상태를 'deleting'으로 변경
+ * - JobQueueService를 통해 destroy Job 전송
+ */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class VmDeleteService {
 
     private final VmInstanceRepository vmInstanceRepository;
-    private final VmDeletionProducer deletionProducer;
+    private final JobQueueService jobQueueService;
 
+    /**
+     * VM 삭제 요청
+     *
+     * @param vmId 삭제할 VM ID
+     * @param requestedBy 요청자 User ID
+     * @return 삭제 Job 정보
+     * @throws ResponseStatusException VM을 찾을 수 없거나 이미 삭제 중인 경우
+     */
+    @Transactional
     public DeleteVmResponse enqueueDeletion(Long vmId, Long requestedBy) {
+        log.info("🗑️ [VmDeleteService] VM 삭제 요청: vmId={}, requestedBy={}", vmId, requestedBy);
+
+        // 1. VM 조회
         VmInstance vm = vmInstanceRepository.findById(vmId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "VM not found: " + vmId));
+                .orElseThrow(() -> {
+                    log.error("❌ [VmDeleteService] VM not found: vmId={}", vmId);
+                    return new ResponseStatusException(HttpStatus.NOT_FOUND, "VM not found: " + vmId);
+                });
 
+        // 2. 상태 검증 - 이미 삭제 중이거나 삭제된 경우
+        if ("deleting".equalsIgnoreCase(vm.getLifecycle())) {
+            log.warn("⚠️ [VmDeleteService] VM already deleting: vmId={}, lifecycle={}",
+                    vmId, vm.getLifecycle());
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "VM is already being deleted: " + vm.getName()
+            );
+        }
+
+        if ("deleted".equalsIgnoreCase(vm.getLifecycle())) {
+            log.warn("⚠️ [VmDeleteService] VM already deleted: vmId={}, lifecycle={}",
+                    vmId, vm.getLifecycle());
+            throw new ResponseStatusException(
+                    HttpStatus.GONE,
+                    "VM has already been deleted: " + vm.getName()
+            );
+        }
+
+        // 3. 삭제 Job ID 생성
         String jobId = UUID.randomUUID().toString();
-        // 실제로는 MQ/Kafka/SQS 등에 전송
-        deletionProducer.enqueue(jobId, vm.getId(), requestedBy);
 
-        return DeleteVmResponse.builder()
+        // 4. VM 상태를 'deleting'으로 변경
+        vm.setLifecycle("deleting");
+        vm.setUpdatedAt(Instant.now());
+        vm.setUpdatedBy(requestedBy);
+        vmInstanceRepository.save(vm);
+
+        log.info("✅ [VmDeleteService] VM lifecycle updated to 'deleting': " +
+                        "vmId={}, vmName={}, previousLifecycle={}",
+                vmId, vm.getName(), vm.getLifecycle());
+
+        // 5. JobQueueService를 통해 destroy Job 전송
+        try {
+            jobQueueService.pushDeleteJob(jobId, vm, requestedBy);
+            log.info("📤 [VmDeleteService] Destroy job enqueued: jobId={}, vmId={}",
+                    jobId, vmId);
+        } catch (Exception e) {
+            log.error("❌ [VmDeleteService] Failed to enqueue destroy job: " +
+                    "jobId={}, vmId={}", jobId, vmId, e);
+
+            // Job 전송 실패 시 상태 롤백
+            vm.setLifecycle("running");  // 원래 상태로 복구 (가정)
+            vm.setUpdatedAt(Instant.now());
+            vmInstanceRepository.save(vm);
+
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to enqueue VM deletion job: " + e.getMessage()
+            );
+        }
+
+        // 6. 응답 생성
+        DeleteVmResponse response = DeleteVmResponse.builder()
                 .jobId(jobId)
                 .vmId(vm.getId())
+                .vmName(vm.getName())
                 .status("QUEUED")
                 .requestedBy(requestedBy)
+                .requestedAt(Instant.now())
+                .message("VM deletion job has been queued")
+                .providerType(vm.getProviderType())
+                .zoneId(vm.getZoneId())
                 .build();
+
+        log.info("✅ [VmDeleteService] VM 삭제 요청 완료: " +
+                        "jobId={}, vmId={}, vmName={}, status={}",
+                jobId, vmId, vm.getName(), response.getStatus());
+
+        return response;
+    }
+
+    /**
+     * VM 삭제 완료 처리 (Worker에서 SUCCESS 이벤트를 받은 후 호출)
+     *
+     * @param vmId 삭제된 VM ID
+     */
+    @Transactional
+    public void markAsDeleted(Long vmId) {
+        log.info("✅ [VmDeleteService] Marking VM as deleted: vmId={}", vmId);
+
+        VmInstance vm = vmInstanceRepository.findById(vmId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "VM not found: " + vmId
+                ));
+
+        vm.setLifecycle("deleted");
+        vm.setPowerState("OFF");
+        vm.setUpdatedAt(Instant.now());
+        vmInstanceRepository.save(vm);
+
+        log.info("✅ [VmDeleteService] VM marked as deleted: vmId={}, vmName={}",
+                vmId, vm.getName());
+    }
+
+    /**
+     * VM 삭제 실패 처리 (Worker에서 ERROR 이벤트를 받은 후 호출)
+     *
+     * @param vmId 삭제 실패한 VM ID
+     * @param errorMessage 에러 메시지
+     */
+    @Transactional
+    public void markDeletionFailed(Long vmId, String errorMessage) {
+        log.error("❌ [VmDeleteService] VM deletion failed: vmId={}, error={}",
+                vmId, errorMessage);
+
+        VmInstance vm = vmInstanceRepository.findById(vmId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "VM not found: " + vmId
+                ));
+
+        // 삭제 실패 시 상태를 다시 'running'으로 복구 (또는 'deletion_failed' 등 별도 상태 추가)
+        vm.setLifecycle("running");
+        vm.setUpdatedAt(Instant.now());
+        vmInstanceRepository.save(vm);
+
+        log.warn("⚠️ [VmDeleteService] VM lifecycle reverted to 'running' after deletion failure: " +
+                "vmId={}, vmName={}", vmId, vm.getName());
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/vm/VmDeleteService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/vm/VmDeleteService.java
@@ -19,6 +19,14 @@ import java.util.UUID;
  * - VM 삭제 요청 처리
  * - lifecycle 상태를 'deleting'으로 변경
  * - JobQueueService를 통해 destroy Job 전송
+ *
+ * 💡 주의:
+ *  - 실제 Terraform destroy 시에는 VM 생성 시점에 사용된 tf_run의 state 파일이 필요하다.
+ *  - 따라서 JobQueueService.pushDeleteJob(...) 내부에서
+ *      - vm.getId()      → additionalConfig.vmId
+ *      - vm.getTfRunId() → additionalConfig.tfRunId
+ *      - vm.getStateUri()→ additionalConfig.stateUri
+ *    를 넣어줘야 TerraformExecutor 가 destroy 시 이전 state 를 재사용할 수 있다.
  */
 @Service
 @RequiredArgsConstructor
@@ -66,10 +74,28 @@ public class VmDeleteService {
             );
         }
 
-        // 3. 삭제 Job ID 생성
+        // 3. Terraform state 연동 정보 로그 (디버깅/운영상 확인용)
+        Long tfRunId = vm.getTfRunId();
+        String stateUri = vm.getStateUri();
+
+        log.info("🧩 [VmDeleteService] Current VM state before deletion: " +
+                        "vmId={}, vmName={}, tfRunId={}, stateUri={}",
+                vmId, vm.getName(), tfRunId, stateUri);
+
+        if (stateUri == null || stateUri.isBlank()) {
+            // 여기서 에러를 던지지 않고 경고만 남긴다.
+            // - 이미 수동으로 삭제된 VM을 DB 상에서만 정리할 수도 있기 때문.
+            // - Terraform 관점에서는 state 없이 destroy를 실행하면 "삭제할 리소스 없음"으로 끝난다.
+            log.warn("⚠️ [VmDeleteService] VM {} 는 stateUri 가 없어 Terraform 기반 자동 삭제는 수행되지 않을 수 있음. " +
+                            "이미 vSphere 에서 수동 삭제된 VM 이거나, 이전 버전에서 생성된 VM 일 수 있음.",
+                    vmId);
+        }
+
+        // 4. 삭제 Job ID 생성 (워커에서 사용하는 논리적 jobId)
         String jobId = UUID.randomUUID().toString();
 
-        // 4. VM 상태를 'deleting'으로 변경
+        // 5. VM 상태를 'deleting'으로 변경
+        String previousLifecycle = vm.getLifecycle();   // 로그/롤백용으로 먼저 저장
         vm.setLifecycle("deleting");
         vm.setUpdatedAt(Instant.now());
         vm.setUpdatedBy(requestedBy);
@@ -77,11 +103,13 @@ public class VmDeleteService {
 
         log.info("✅ [VmDeleteService] VM lifecycle updated to 'deleting': " +
                         "vmId={}, vmName={}, previousLifecycle={}",
-                vmId, vm.getName(), vm.getLifecycle());
+                vmId, vm.getName(), previousLifecycle);
 
-        // 5. JobQueueService를 통해 destroy Job 전송
+        // 6. JobQueueService를 통해 destroy Job 전송
         try {
+            // 💡 pushDeleteJob 내부에서 vmId / tfRunId / stateUri 를 additionalConfig에 넣어야 함
             jobQueueService.pushDeleteJob(jobId, vm, requestedBy);
+
             log.info("📤 [VmDeleteService] Destroy job enqueued: jobId={}, vmId={}",
                     jobId, vmId);
         } catch (Exception e) {
@@ -89,7 +117,7 @@ public class VmDeleteService {
                     "jobId={}, vmId={}", jobId, vmId, e);
 
             // Job 전송 실패 시 상태 롤백
-            vm.setLifecycle("running");  // 원래 상태로 복구 (가정)
+            vm.setLifecycle(previousLifecycle != null ? previousLifecycle : "running");
             vm.setUpdatedAt(Instant.now());
             vmInstanceRepository.save(vm);
 
@@ -99,7 +127,7 @@ public class VmDeleteService {
             );
         }
 
-        // 6. 응답 생성
+        // 7. 응답 생성
         DeleteVmResponse response = DeleteVmResponse.builder()
                 .jobId(jobId)
                 .vmId(vm.getId())
@@ -121,8 +149,6 @@ public class VmDeleteService {
 
     /**
      * VM 삭제 완료 처리 (Worker에서 SUCCESS 이벤트를 받은 후 호출)
-     *
-     * @param vmId 삭제된 VM ID
      */
     @Transactional
     public void markAsDeleted(Long vmId) {
@@ -145,9 +171,6 @@ public class VmDeleteService {
 
     /**
      * VM 삭제 실패 처리 (Worker에서 ERROR 이벤트를 받은 후 호출)
-     *
-     * @param vmId 삭제 실패한 VM ID
-     * @param errorMessage 에러 메시지
      */
     @Transactional
     public void markDeletionFailed(Long vmId, String errorMessage) {
@@ -160,7 +183,6 @@ public class VmDeleteService {
                         "VM not found: " + vmId
                 ));
 
-        // 삭제 실패 시 상태를 다시 'running'으로 복구 (또는 'deletion_failed' 등 별도 상태 추가)
         vm.setLifecycle("running");
         vm.setUpdatedAt(Instant.now());
         vmInstanceRepository.save(vm);

--- a/src/main/java/com/cloudrangers/cloudpilot/service/vm/VmProvisionService.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/vm/VmProvisionService.java
@@ -29,53 +29,93 @@ public class VmProvisionService {
     /**
      * 프로비저닝 성공 시, 결과 메시지에 포함된 instance 정보를
      * vm_instance 테이블에 저장
+     *
+     * - tf_run_id  : 워커가 result.tfRunId에 넣어준 값 (없으면 null)
+     * - state_uri  : BE에서 jobId 기준으로 생성 (/tmp/terraform/{jobId}/terraform.tfstate)
      */
     @Transactional
     public void handleProvisionSuccess(VmProvisionJob job, ProvisionResultMessage result) {
         List<InstanceInfo> instances = result.getInstances();
+
+        log.info("[VmProvisionService] handleProvisionSuccess 호출. jobId={}, resultStatus={}, step={}, instanceCount={}",
+                job.getId(),
+                result.getStatus(),
+                result.getStep(),
+                (instances == null ? 0 : instances.size()));
+
         if (instances == null || instances.isEmpty()) {
             log.warn("[VmProvisionService] Job {} - instances 비어 있음. vm_instance 저장 스킵", job.getId());
             return;
         }
 
-        for (InstanceInfo info : instances) {
-            Instant now = Instant.now();
+        Long tfRunId = result.getTfRunId();
+        String stateUri = buildTerraformStateUri(job.getId());
 
-            // VM 이름 한 번 계산 (null/blank 시 fallback)
-            String name = defaultString(info.getName(), "vm-" + job.getId());
+        log.info("[VmProvisionService] jobId={}, tfRunId={}, stateUri={}",
+                job.getId(), tfRunId, stateUri);
 
-            // 대표 IP (vm_instance.ip와 동일하게 사용)
-            String ip = resolveIp(info);
+        try {
+            for (InstanceInfo info : instances) {
+                Instant now = Instant.now();
 
-            VmInstance vm = VmInstance.builder()
-                    .name(name)
-                    .providerType(defaultString(info.getProviderType(), "VSPHERE"))
-                    .zoneId(resolveZoneId(info, job))
-                    .lifecycle("running")
-                    .powerState("ON")
-                    .vcpu(info.getCpuCores())
-                    .memoryMb(info.getMemoryGb() != null ? info.getMemoryGb() * 1024 : null)
-                    .rootDiskGb(info.getDiskGb())
-                    .ownerUserId(job.getUserId())
-                    .teamId(job.getTeamId())
-                    .createdAt(now)
-                    .createdBy(job.getUserId())
-                    .updatedAt(now)
-                    .updatedBy(job.getUserId())
-                    .tags(buildTags(info, name, ip))
-                    .ip(ip)
-                    .build();
+                String name = defaultString(info.getName(), "vm-" + job.getId());
+                String ip = resolveIp(info);
+                String providerInstanceId = normalizeBlankToNull(info.getExternalId());
 
-            VmInstance saved = vmInstanceRepository.save(vm);
+                Long zoneId = resolveZoneId(info, job);
 
-            log.info("[VmProvisionService] vm_instance 저장 완료. jobId={}, vmInstanceId={}, name={}, zoneId={}, ip={}",
-                    job.getId(), saved.getId(), saved.getName(), saved.getZoneId(), saved.getIp());
+                log.debug("[VmProvisionService] vm_instance 생성 준비. jobId={}, name={}, ip={}, zoneId={}, providerInstanceId={}",
+                        job.getId(), name, ip, zoneId, providerInstanceId);
+
+                VmInstance vm = VmInstance.builder()
+                        .name(name)
+                        .providerType(defaultString(info.getProviderType(), "VSPHERE"))
+
+                        // 위치/소유 정보
+                        .zoneId(zoneId)
+                        .ownerUserId(job.getUserId())
+                        .teamId(job.getTeamId())
+
+                        // 라이프사이클/전원 상태
+                        .lifecycle("running")
+                        .powerState("ON")
+
+                        // 스펙
+                        .vcpu(info.getCpuCores())
+                        .memoryMb(info.getMemoryGb() != null ? info.getMemoryGb() * 1024 : null)
+                        .rootDiskGb(info.getDiskGb())
+
+                        // 연동 정보
+                        .tfRunId(tfRunId)
+                        .stateUri(stateUri)
+
+                        // 네트워크
+                        .ip(ip)
+
+                        // 태그(JSON)
+                        .tags(buildTags(info, name, ip))
+
+                        // 메타데이터
+                        .createdAt(now)
+                        .createdBy(job.getUserId())
+                        .updatedAt(now)
+                        .updatedBy(job.getUserId())
+                        .build();
+
+                VmInstance saved = vmInstanceRepository.save(vm);
+
+                log.info(
+                        "[VmProvisionService] vm_instance 저장 완료. jobId={}, vmInstanceId={}, name={}, zoneId={}, ip={}, tfRunId={}, stateUri={}",
+                        job.getId(), saved.getId(), saved.getName(), saved.getZoneId(), saved.getIp(),
+                        saved.getTfRunId(), saved.getStateUri()
+                );
+            }
+        } catch (Exception e) {
+            log.error("[VmProvisionService] vm_instance 저장 중 예외 발생. jobId={}", job.getId(), e);
+            throw e; // 트랜잭션 롤백되게 그대로 다시 던짐
         }
     }
 
-    /**
-     * InstanceInfo 또는 Job 에서 zoneId 결정
-     */
     private Long resolveZoneId(InstanceInfo info, VmProvisionJob job) {
         if (info.getZoneId() != null) {
             return info.getZoneId();
@@ -86,40 +126,24 @@ public class VmProvisionService {
         return null;
     }
 
-    /**
-     * vm_instance.tags 필드에 저장할 통일된 태그 구조
-     *
-     * {
-     *   "externalId": "vm-473",
-     *   "vmName": "Vmprovision-db-ip-test123123",
-     *   "primaryIp": "172.16.5.109",
-     *   "nicIps": ["172.16.5.109"],
-     *   "osType": "ubuntu"
-     * }
-     */
     private String buildTags(InstanceInfo info, String vmName, String primaryIp) {
         Map<String, Object> m = new LinkedHashMap<>();
 
-        // 1) vSphere VM ID (MoRef 또는 UUID)
         if (info.getExternalId() != null && !info.getExternalId().isBlank()) {
             m.put("externalId", info.getExternalId().trim());
         }
 
-        // 2) VM 이름 (CloudPilot 상 이름과 동일)
         m.put("vmName", vmName);
 
-        // 3) 대표 IP (vm_instance.ip와 동일)
         if (primaryIp != null && !primaryIp.isBlank()) {
             m.put("primaryIp", primaryIp.trim());
         }
 
-        // 4) NIC 별 IP 리스트
         List<String> nicIps = parseNicAddresses(info.getNicAddresses());
         if (!nicIps.isEmpty()) {
             m.put("nicIps", nicIps);
         }
 
-        // 5) OS 타입
         if (info.getOsType() != null && !info.getOsType().isBlank()) {
             m.put("osType", info.getOsType().trim());
         }
@@ -137,9 +161,6 @@ public class VmProvisionService {
         }
     }
 
-    /**
-     * "172.16.0.10,172.16.0.11" → ["172.16.0.10", "172.16.0.11"]
-     */
     private List<String> parseNicAddresses(String nicAddresses) {
         List<String> result = new ArrayList<>();
         if (nicAddresses == null || nicAddresses.isBlank()) {
@@ -156,11 +177,6 @@ public class VmProvisionService {
         return result;
     }
 
-    /**
-     * 팀 네트워크용 대표 IP 결정 로직
-     * 1) ipAddress 가 있으면 그걸 사용
-     * 2) 없으면 nicAddresses 에서 첫 번째 IP 사용
-     */
     private String resolveIp(InstanceInfo info) {
         if (info.getIpAddress() != null && !info.getIpAddress().isBlank()) {
             return info.getIpAddress().trim();
@@ -176,5 +192,18 @@ public class VmProvisionService {
 
     private String defaultString(String value, String def) {
         return (value == null || value.isBlank()) ? def : value;
+    }
+
+    private String normalizeBlankToNull(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String buildTerraformStateUri(Long jobId) {
+        if (jobId == null) {
+            return null;
+        }
+        return "/tmp/terraform/" + jobId + "/terraform.tfstate";
     }
 }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/vm/producer/SimpleVmDeletionProducer.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/vm/producer/SimpleVmDeletionProducer.java
@@ -1,5 +1,6 @@
 package com.cloudrangers.cloudpilot.service.vm.producer;
 
+import com.cloudrangers.cloudpilot.domain.vm.VmInstance;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -7,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SimpleVmDeletionProducer implements VmDeletionProducer {
     @Override
-    public void enqueue(String jobId, Long vmId, Long requestedBy) {
+    public void enqueue(String jobId, VmInstance vmId, Long requestedBy) {
         // 실제 메시징 대신 로그로 대체
         log.info("[VM-DELETE-ENQUEUE] jobId={}, vmId={}, requestedBy={}", jobId, vmId, requestedBy);
     }

--- a/src/main/java/com/cloudrangers/cloudpilot/service/vm/producer/VmDeletionProducer.java
+++ b/src/main/java/com/cloudrangers/cloudpilot/service/vm/producer/VmDeletionProducer.java
@@ -1,5 +1,7 @@
 package com.cloudrangers.cloudpilot.service.vm.producer;
 
+import com.cloudrangers.cloudpilot.domain.vm.VmInstance;
+
 public interface VmDeletionProducer {
-    void enqueue(String jobId, Long vmId, Long requestedBy);
+    void enqueue(String jobId, VmInstance vmId, Long requestedBy);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,6 +58,7 @@ rabbitmq.queue.dlq.name=provision-jobs-dlq
 rabbitmq.routing-key.provision=provision.#
 rabbitmq.routing-key.result=result.provision.#
 rabbitmq.routing-key.dlq=provision.dlq
+rabbitmq.routing-key.result.pattern=#
 
 
 rabbitmq.dlx.exchange=${rabbitmq.exchange.dlx.name}


### PR DESCRIPTION
📌 Summary

- VM 삭제 기능을 위한 VM 생성 기능 리팩토링
- DB 수정
- VM 삭제 기능 구현

✍️ Description

- close: #55 

💡 PR Point

- 

📚 Reference

🔥 Test
<img width="838" height="529" alt="스크린샷 2025-11-28 14 45 57" src="https://github.com/user-attachments/assets/a04c12d2-9ae0-469d-a094-e8bd5faf1c08" />
<img width="1442" height="337" alt="스크린샷 2025-11-28 14 46 15" src="https://github.com/user-attachments/assets/ddfdfe2a-76c9-4a4c-b206-3f16c12afe33" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * VM 삭제가 비동기(202 Accepted) 처리로 변경되고, 인증 사용자만 삭제 요청 가능
  * 삭제 응답에 vmName, requestedAt, message, providerType, zoneId 등 상세 메타데이터 추가

* **개선 사항**
  * 프로비저닝 전반에 Terraform 실행 참조(tfRunId)와 상태 파일 경로(stateUri)가 전달·추적됨
  * VM 생성/삭제 시 더 풍부한 메타데이터와 로깅, API 문서(스웨거) 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->